### PR TITLE
Fix GitHub Actions workflow for documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     
@@ -44,7 +44,7 @@ jobs:
         make html
     
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: 'docs/build/html'
 
@@ -52,10 +52,10 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:
       name: github-pages
-      url: $page_url
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fix deprecated action versions that were causing workflow failures.

## Changes
- Update actions/setup-python from v4 to v5
- Update actions/upload-pages-artifact from v2 to v3  
- Update actions/deploy-pages from v3 to v4
- Fix deployment URL output syntax

This resolves the error:
`This request has been automatically failed because it uses a deprecated version`

After merging, the documentation will deploy correctly to GitHub Pages.