### PR TITLE
Refactor particle pushers into per-type kernels

### DIFF
--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -84,6 +84,8 @@ MeshBoundaryValues::~MeshBoundaryValues() {
     delete [] recvbuf[n].vars_req;
     delete [] recvbuf[n].flux_req;
   }
+  MPI_Comm_free(&comm_vars);
+  MPI_Comm_free(&comm_flux);
 #endif
 }
 
@@ -251,4 +253,8 @@ particles::ParticlesBoundaryValues::ParticlesBoundaryValues(
 // destructor
 
 particles::ParticlesBoundaryValues::~ParticlesBoundaryValues() {
+  // Free MPI communicator if it was allocated
+#if MPI_PARALLEL_ENABLED
+  MPI_Comm_free(&mpi_comm_part);
+#endif
 }

--- a/src/bvals/bvals_part.cpp
+++ b/src/bvals/bvals_part.cpp
@@ -80,7 +80,6 @@ TaskStatus ParticlesBoundaryValues::SetNewPrtclGID() {
   auto &pdestroyl = destroylist;
   bool &multi_d = pmy_part->pmy_pack->pmesh->multi_d;
   bool &three_d = pmy_part->pmy_pack->pmesh->three_d;
-  auto par_type = pmy_part->particle_type;
   auto &mb_bcs = pmy_part->pmy_pack->pmb->mb_bcs;
 
   // Create device-side counter

--- a/src/particles/particles.cpp
+++ b/src/particles/particles.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <algorithm>
 #include <fstream>
+#include <Kokkos_Random.hpp>
 #include "athena.hpp"
 #include "globals.hpp"
 #include "parameter_input.hpp"
@@ -145,24 +146,16 @@ Particles::Particles(MeshBlockPack *ppack, ParameterInput *pin) :
   switch (particle_type) {
     case ParticleType::cosmic_ray:
       {
-        // CR particles need space for position, velocity, mass/charge, B-field, and optionally displacement
-        int ndim = 6;  // x,vx,y,vy,z,vz in 3D
-        if (pmy_pack->pmesh->two_d) {ndim = 4;}  // x,vx,y,vy in 2D
-        nrdata = ndim + 1;  // add mass/charge ratio
-        
-        // Add B-field components
-        if (pmy_pack->pmesh->three_d) {
-          nrdata += 3;  // Bx, By, Bz
-        } else {
-          nrdata += 2;  // Bx, By for 2D
-        }
-        
-        // Add displacement tracking if enabled
+        // Determine number of real data slots based on dimensionality and options
         track_displacement = pin->GetOrAddBoolean("particles","track_displacement",false);
         if (track_displacement) {
-          nrdata += 4;  // dx, dy, dz, db
+          nrdata = IPDB + 1;  // includes displacement indices
+        } else if (pmy_pack->pmesh->three_d) {
+          nrdata = IPBZ + 1;  // up to Bz
+        } else {
+          nrdata = IPBY + 1;  // up to By in 2D
         }
-        
+
         nidata = 3;  // PGID, PTAG, PSP (species)
         break;
       }
@@ -205,7 +198,6 @@ Particles::Particles(MeshBlockPack *ppack, ParameterInput *pin) :
 
       auto &pi = prtcl_idata;
       auto &pr = prtcl_rdata;
-      int nrdata_ = nrdata;
       Real unit_time = pmy_pack->punit->time_cgs();
 
       // Initialize particles
@@ -213,16 +205,16 @@ Particles::Particles(MeshBlockPack *ppack, ParameterInput *pin) :
       KOKKOS_LAMBDA(const int p) {   
         int m = static_cast<int>(pos_data(8, p));  
         pi(PGID,p) = gids + m;
-	pi(2, p) = 0; // int to track # of SN
+        pi(NSN,p) = 0; // track number of SNe for star particle
         pr(IPX,p)  = pos_data(0, p);
         pr(IPY,p)  = pos_data(1, p);
         pr(IPZ,p)  = pos_data(2, p);
         pr(IPVX,p) = pos_data(3, p);
         pr(IPVY,p) = pos_data(4, p);
         pr(IPVZ,p) = pos_data(5, p);
-        pr(6, p) = pos_data(6, p); // time of creation of star particle
-        pr(7, p) = pos_data(7, p); // mass of star particle
-	pr(8, p) = GetNthSNTime(pr(7,p), pr(6,p), unit_time, 0); // time of next SN
+        pr(IPT_CREATE, p) = pos_data(6, p); // creation time of star particle
+        pr(IPMASS, p)     = pos_data(7, p); // mass of star particle
+        pr(IPT_NEXT_SN,p) = GetNthSNTime(pr(IPMASS,p), pr(IPT_CREATE,p), unit_time, 0);
 
         // Print particle initialization
         // Kokkos::printf("Initialized star particle %d in GID %d at position (%.2f, %.2f, %.2f)\n",
@@ -238,6 +230,7 @@ Particles::Particles(MeshBlockPack *ppack, ParameterInput *pin) :
 // destructor
 
 Particles::~Particles() {
+  delete pbval_part;
 }
 
 //----------------------------------------------------------------------------------------
@@ -272,46 +265,64 @@ void Particles::InitializeCosmicRays(ParameterInput *pin) {
   auto &pr = prtcl_rdata;
   int nmb = pmy_pack->nmb_thispack;
   const int &gids = pmy_pack->gids;
-  
+
+  // Determine distribution type for initial positions
+  std::string dist = pin->GetOrAddString("particles", "cr_distribution", "center");
+  bool random_dist = (dist.compare("random") == 0);
+
+  // Avoid division by zero if there are fewer particles than meshblocks
+  int particles_per_mb = std::max(1, (nprtcl_thispack + nmb - 1) / nmb);
+
+  // Random number pool for optional random placement
+  Kokkos::Random_XorShift64_Pool<> rand_pool64(pmy_pack->gids);
+
   // Simple uniform distribution for now
   par_for("init_cr", DevExeSpace(), 0, nprtcl_thispack-1,
   KOKKOS_LAMBDA(const int p) {
     // Determine which meshblock this particle belongs to
-    int particles_per_mb = nprtcl_thispack / nmb;
     int m = p / particles_per_mb;
     if (m >= nmb) m = nmb - 1;
-    
+
     // Set GID and species
     pi(PGID,p) = gids + m;
     pi(PTAG,p) = p;
     pi(PSP,p) = p % nspecies;  // Round-robin species assignment
-    
-    // Initialize position (uniform random for now)
-    // TODO: Add proper initialization options
-    pr(IPX,p) = size.h_view(m).x1min + 0.5*(size.h_view(m).x1max - size.h_view(m).x1min);
-    pr(IPY,p) = size.h_view(m).x2min + 0.5*(size.h_view(m).x2max - size.h_view(m).x2min);
-    if (indcs.nx3 > 1) {
-      pr(IPZ,p) = size.h_view(m).x3min + 0.5*(size.h_view(m).x3max - size.h_view(m).x3min);
+
+    // Choose position within the mesh block
+    Real rx = 0.5, ry = 0.5, rz = 0.5;
+    if (random_dist) {
+      auto rand_gen = rand_pool64.get_state();
+      rx = rand_gen.drand();
+      ry = rand_gen.drand();
+      if (indcs.nx3 > 1) {
+        rz = rand_gen.drand();
+      }
+      rand_pool64.free_state(rand_gen);
     }
-    
+
+    pr(IPX,p) = size.h_view(m).x1min + rx*(size.h_view(m).x1max - size.h_view(m).x1min);
+    pr(IPY,p) = size.h_view(m).x2min + ry*(size.h_view(m).x2max - size.h_view(m).x2min);
+    pr(IPZ,p) = 0.0;
+    if (indcs.nx3 > 1) {
+      pr(IPZ,p) = size.h_view(m).x3min + rz*(size.h_view(m).x3max - size.h_view(m).x3min);
+    }
+
     // Initialize velocity to zero
     pr(IPVX,p) = 0.0;
     pr(IPVY,p) = 0.0;
-    if (indcs.nx3 > 1) {
-      pr(IPVZ,p) = 0.0;
-    }
-    
+    pr(IPVZ,p) = 0.0;
+
     // Set mass/charge ratio
     int species = pi(PSP,p);
     pr(IPM,p) = species_charge(species) / species_mass(species);
-    
+
     // Initialize B-field components to zero
     pr(IPBX,p) = 0.0;
     pr(IPBY,p) = 0.0;
     if (indcs.nx3 > 1) {
       pr(IPBZ,p) = 0.0;
     }
-    
+
     // Initialize displacement tracking if enabled
     if (track_displacement) {
       pr(IPDX,p) = 0.0;

--- a/src/particles/particles.hpp
+++ b/src/particles/particles.hpp
@@ -13,18 +13,25 @@
 #include <string>
 
 #include "athena.hpp"
+#include "bvals/bvals.hpp"
 #include "parameter_input.hpp"
 #include "tasklist/task_list.hpp"
-#include "bvals/bvals.hpp"
 
 // forward declarations
 
 // constants that enumerate ParticlesPusher options
-enum class ParticlesPusher {drift, rk4_gravity, leap_frog, lagrangian_tracer, lagrangian_mc,
-                            boris_lin, boris_tsc};
+enum class ParticlesPusher {
+  drift,
+  rk4_gravity,
+  leap_frog,
+  lagrangian_tracer,
+  lagrangian_mc,
+  boris_lin,
+  boris_tsc
+};
 
 // constants that enumerate ParticleTypes
-enum class ParticleType {cosmic_ray, star};
+enum class ParticleType { cosmic_ray, star };
 
 //----------------------------------------------------------------------------------------
 //! \struct ParticlesTaskIDs
@@ -48,26 +55,29 @@ namespace particles {
 
 class Particles {
   friend class ParticlesBoundaryValues;
- public:
+
+public:
   Particles(MeshBlockPack *ppack, ParameterInput *pin);
   ~Particles();
 
   // data
   ParticleType particle_type;
-  int nprtcl_thispack;             // number of particles this MeshBlockPack
+  int nprtcl_thispack; // number of particles this MeshBlockPack
   int nrdata, nidata;
-  DvceArray2D<Real> prtcl_rdata;   // real number properties each particle (x,v,etc.)
-  DvceArray2D<int>  prtcl_idata;   // integer properties each particle (gid, tag, etc.)
+  DvceArray2D<Real>
+      prtcl_rdata; // real number properties each particle (x,v,etc.)
+  DvceArray2D<int>
+      prtcl_idata; // integer properties each particle (gid, tag, etc.)
   Real dtnew;
 
   ParticlesPusher pusher;
-  
+
   // Cosmic ray specific
-  int nspecies;                    // number of CR species
-  bool track_displacement;         // enable displacement tracking
-  DvceArray1D<Real> species_mass;  // mass per species
-  DvceArray1D<Real> species_charge;// charge per species
- 
+  int nspecies;                     // number of CR species
+  bool track_displacement;          // enable displacement tracking
+  DvceArray1D<Real> species_mass;   // mass per species
+  DvceArray1D<Real> species_charge; // charge per species
+
   // Constants for rk4_gravity pusher
   Real r_scale;
   Real rho_scale;
@@ -95,22 +105,23 @@ class Particles {
   TaskStatus RecvP(Driver *pdriver, int stage);
   TaskStatus ClearSend(Driver *pdriver, int stage);
   TaskStatus ClearRecv(Driver *pdriver, int stage);
-  
+
   // Cosmic ray specific methods
   void InitializeCosmicRays(ParameterInput *pin);
+  TaskStatus PushDrift(Driver *pdriver, int stage);
   TaskStatus PushCosmicRays(Driver *pdriver, int stage);
   TaskStatus PushStars(Driver *pdriver, int stage);
-  
+
   // Field interpolation methods
   KOKKOS_INLINE_FUNCTION
-  void InterpolateLinear(int m, Real x, Real y, Real z,
-                        Real &Bx, Real &By, Real &Bz) const;
+  void InterpolateLinear(int m, Real x, Real y, Real z, Real &Bx, Real &By,
+                         Real &Bz) const;
   KOKKOS_INLINE_FUNCTION
-  void InterpolateTSC(int m, Real x, Real y, Real z,
-                     Real &Bx, Real &By, Real &Bz) const;
+  void InterpolateTSC(int m, Real x, Real y, Real z, Real &Bx, Real &By,
+                      Real &Bz) const;
 
- private:
-  MeshBlockPack* pmy_pack;  // ptr to MeshBlockPack containing this Particles
+private:
+  MeshBlockPack *pmy_pack; // ptr to MeshBlockPack containing this Particles
 };
 
 } // namespace particles

--- a/src/particles/particles_pushers.cpp
+++ b/src/particles/particles_pushers.cpp
@@ -6,157 +6,175 @@
 //! \file particle_pushers.cpp
 //  \brief
 
+#include <cmath>
+#include <iostream>
+
 #include "athena.hpp"
-#include "mesh/mesh.hpp"
 #include "driver/driver.hpp"
+#include "mesh/mesh.hpp"
+#include "mhd/mhd.hpp"
 #include "particles.hpp"
 #include "units/units.hpp"
-#include "mhd/mhd.hpp"
 
 namespace particles {
 KOKKOS_INLINE_FUNCTION
-Real GravPot(Real x1, Real x2, Real x3,
-             Real G, Real r_s, Real rho_s,
-             Real M_gal, Real a_gal, Real z_gal,
-             Real R200, Real rho_mean);
+Real GravPot(Real x1, Real x2, Real x3, Real G, Real r_s, Real rho_s,
+             Real M_gal, Real a_gal, Real z_gal, Real R200, Real rho_mean);
 
 //----------------------------------------------------------------------------------------
 //! \fn void Particles::ParticlesPush
 //  \brief
 
 TaskStatus Particles::Push(Driver *pdriver, int stage) {
-  auto &indcs = pmy_pack->pmesh->mb_indcs;
-  int is = indcs.is;
-  int js = indcs.js;
-  int ks = indcs.ks;
+  switch (pusher) {
+  case ParticlesPusher::drift:
+    return PushDrift(pdriver, stage);
+  case ParticlesPusher::rk4_gravity:
+    return PushStars(pdriver, stage);
+  case ParticlesPusher::boris_lin:
+  case ParticlesPusher::boris_tsc:
+    return PushCosmicRays(pdriver, stage);
+  default:
+    return TaskStatus::fail;
+  }
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void Particles::PushDrift
+//! \brief Simple drift pusher updating positions using velocities
+
+TaskStatus Particles::PushDrift(Driver *pdriver, int stage) {
   bool &multi_d = pmy_pack->pmesh->multi_d;
   bool &three_d = pmy_pack->pmesh->three_d;
-  auto &mbsize = pmy_pack->pmb->mb_size;
-  auto &pi = prtcl_idata;
   auto &pr = prtcl_rdata;
   auto dt_ = (pmy_pack->pmesh->dt);
-  auto gids = pmy_pack->gids;
 
-  switch (pusher) {
-    case ParticlesPusher::drift: {
-      par_for("part_update",DevExeSpace(),0,(nprtcl_thispack-1),
+  par_for(
+      "part_update", DevExeSpace(), 0, (nprtcl_thispack - 1),
       KOKKOS_LAMBDA(const int p) {
-        int m = pi(PGID,p) - gids;
-        int ip = (pr(IPX,p) - mbsize.d_view(m).x1min)/mbsize.d_view(m).dx1 + is;
-        pr(IPX,p) += dt_*pr(IPVX,p);
+        pr(IPX, p) += dt_ * pr(IPVX, p);
 
         if (multi_d) {
-          int jp = (pr(IPY,p) - mbsize.d_view(m).x2min)/mbsize.d_view(m).dx2 + js;
-          pr(IPY,p) += dt_*pr(IPVY,p);
+          pr(IPY, p) += dt_ * pr(IPVY, p);
         }
 
         if (three_d) {
-          int kp = (pr(IPZ,p) - mbsize.d_view(m).x3min)/mbsize.d_view(m).dx3 + ks;
-          pr(IPZ,p) += dt_*pr(IPVZ,p);
+          pr(IPZ, p) += dt_ * pr(IPVZ, p);
         }
       });
-    break;}
-    case ParticlesPusher::rk4_gravity:{
-      Real G = pmy_pack->punit->grav_constant();
-      Real r_s = r_scale;
-      Real rho_s = rho_scale;
-      Real m_g = m_gal;
-      Real a_g = a_gal;
-      Real z_g = z_gal;
-      Real r_m = r_200;
-      Real rho_m = rho_mean;
-      Real h = par_grav_dx;
 
-      par_for("part_rk4_gravity", DevExeSpace(), 0, (nprtcl_thispack-1),
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void Particles::PushStars
+//! \brief RK4 gravity pusher for star particles
+
+TaskStatus Particles::PushStars(Driver *pdriver, int stage) {
+  auto &pr = prtcl_rdata;
+  auto dt_ = (pmy_pack->pmesh->dt);
+
+  Real G = pmy_pack->punit->grav_constant();
+  Real r_s = r_scale;
+  Real rho_s = rho_scale;
+  Real m_g = m_gal;
+  Real a_g = a_gal;
+  Real z_g = z_gal;
+  Real r_m = r_200;
+  Real rho_m = rho_mean;
+  Real h = par_grav_dx;
+
+  par_for(
+      "part_rk4_gravity", DevExeSpace(), 0, (nprtcl_thispack - 1),
       KOKKOS_LAMBDA(const int p) {
         // Current state
-        Real x  = pr(IPX, p);
-        Real y  = pr(IPY, p);
-        Real z  = pr(IPZ, p);
+        Real x = pr(IPX, p);
+        Real y = pr(IPY, p);
+        Real z = pr(IPZ, p);
         Real vx = pr(IPVX, p);
         Real vy = pr(IPVY, p);
         Real vz = pr(IPVZ, p);
 
-	auto compute_acc = [&](Real px, Real py, Real pz, Real& ax, Real& ay, Real& az) {
-          Real phi_xp = GravPot(px+h, py, pz, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
-          Real phi_xm = GravPot(px-h, py, pz, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
-          Real phi_yp = GravPot(px, py+h, pz, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
-          Real phi_ym = GravPot(px, py-h, pz, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
-          Real phi_zp = GravPot(px, py, pz+h, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
-          Real phi_zm = GravPot(px, py, pz-h, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
+        auto compute_acc = [&](Real px, Real py, Real pz, Real &ax, Real &ay,
+                               Real &az) {
+          Real phi_xp =
+              GravPot(px + h, py, pz, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
+          Real phi_xm =
+              GravPot(px - h, py, pz, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
+          Real phi_yp =
+              GravPot(px, py + h, pz, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
+          Real phi_ym =
+              GravPot(px, py - h, pz, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
+          Real phi_zp =
+              GravPot(px, py, pz + h, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
+          Real phi_zm =
+              GravPot(px, py, pz - h, G, r_s, rho_s, m_g, a_g, z_g, r_m, rho_m);
 
           ax = -(phi_xp - phi_xm) / (2.0 * h);
           ay = -(phi_yp - phi_ym) / (2.0 * h);
           az = -(phi_zp - phi_zm) / (2.0 * h);
         };
-        
+
         // RK4 coefficients
         Real k1x, k1y, k1z, k1vx, k1vy, k1vz;
         Real k2x, k2y, k2z, k2vx, k2vy, k2vz;
         Real k3x, k3y, k3z, k3vx, k3vy, k3vz;
         Real k4x, k4y, k4z, k4vx, k4vy, k4vz;
-        
+
         // K1: derivatives at current state
         k1x = vx;
         k1y = vy;
         k1z = vz;
         compute_acc(x, y, z, k1vx, k1vy, k1vz);
-        
+
         // K2: derivatives at midpoint using K1
-        Real x_mid1  =  x + 0.5*dt_*k1x;
-        Real y_mid1  =  y + 0.5*dt_*k1y;
-        Real z_mid1  =  z + 0.5*dt_*k1z;
-        Real vx_mid1 = vx + 0.5*dt_*k1vx;
-        Real vy_mid1 = vy + 0.5*dt_*k1vy;
-        Real vz_mid1 = vz + 0.5*dt_*k1vz;
-        
+        Real x_mid1 = x + 0.5 * dt_ * k1x;
+        Real y_mid1 = y + 0.5 * dt_ * k1y;
+        Real z_mid1 = z + 0.5 * dt_ * k1z;
+        Real vx_mid1 = vx + 0.5 * dt_ * k1vx;
+        Real vy_mid1 = vy + 0.5 * dt_ * k1vy;
+        Real vz_mid1 = vz + 0.5 * dt_ * k1vz;
+
         k2x = vx_mid1;
         k2y = vy_mid1;
         k2z = vz_mid1;
         compute_acc(x_mid1, y_mid1, z_mid1, k2vx, k2vy, k2vz);
-        
+
         // K3: derivatives at midpoint using K2
-        Real x_mid2  = x  + 0.5*dt_*k2x;
-        Real y_mid2  = y  + 0.5*dt_*k2y;
-        Real z_mid2  = z  + 0.5*dt_*k2z;
-        Real vx_mid2 = vx + 0.5*dt_*k2vx;
-        Real vy_mid2 = vy + 0.5*dt_*k2vy;
-        Real vz_mid2 = vz + 0.5*dt_*k2vz;
-        
+        Real x_mid2 = x + 0.5 * dt_ * k2x;
+        Real y_mid2 = y + 0.5 * dt_ * k2y;
+        Real z_mid2 = z + 0.5 * dt_ * k2z;
+        Real vx_mid2 = vx + 0.5 * dt_ * k2vx;
+        Real vy_mid2 = vy + 0.5 * dt_ * k2vy;
+        Real vz_mid2 = vz + 0.5 * dt_ * k2vz;
+
         k3x = vx_mid2;
         k3y = vy_mid2;
         k3z = vz_mid2;
         compute_acc(x_mid2, y_mid2, z_mid2, k3vx, k3vy, k3vz);
-        
+
         // K4: derivatives at endpoint using K3
-        Real x_end  = x  + dt_*k3x;
-        Real y_end  = y  + dt_*k3y;
-        Real z_end  = z  + dt_*k3z;
-        Real vx_end = vx + dt_*k3vx;
-        Real vy_end = vy + dt_*k3vy;
-        Real vz_end = vz + dt_*k3vz;
-        
+        Real x_end = x + dt_ * k3x;
+        Real y_end = y + dt_ * k3y;
+        Real z_end = z + dt_ * k3z;
+        Real vx_end = vx + dt_ * k3vx;
+        Real vy_end = vy + dt_ * k3vy;
+        Real vz_end = vz + dt_ * k3vz;
+
         k4x = vx_end;
         k4y = vy_end;
         k4z = vz_end;
         compute_acc(x_end, y_end, z_end, k4vx, k4vy, k4vz);
-        
+
         // Final RK4 update
-        pr(IPX, p) = x + dt_/6.0 * (k1x + 2.0*k2x + 2.0*k3x + k4x);
-        pr(IPY, p) = y + dt_/6.0 * (k1y + 2.0*k2y + 2.0*k3y + k4y);
-        pr(IPZ, p) = z + dt_/6.0 * (k1z + 2.0*k2z + 2.0*k3z + k4z);
-        
-        pr(IPVX, p) = vx + dt_/6.0 * (k1vx + 2.0*k2vx + 2.0*k3vx + k4vx);
-        pr(IPVY, p) = vy + dt_/6.0 * (k1vy + 2.0*k2vy + 2.0*k3vy + k4vy);
-        pr(IPVZ, p) = vz + dt_/6.0 * (k1vz + 2.0*k2vz + 2.0*k3vz + k4vz);
+        pr(IPX, p) = x + dt_ / 6.0 * (k1x + 2.0 * k2x + 2.0 * k3x + k4x);
+        pr(IPY, p) = y + dt_ / 6.0 * (k1y + 2.0 * k2y + 2.0 * k3y + k4y);
+        pr(IPZ, p) = z + dt_ / 6.0 * (k1z + 2.0 * k2z + 2.0 * k3z + k4z);
+
+        pr(IPVX, p) = vx + dt_ / 6.0 * (k1vx + 2.0 * k2vx + 2.0 * k3vx + k4vx);
+        pr(IPVY, p) = vy + dt_ / 6.0 * (k1vy + 2.0 * k2vy + 2.0 * k3vy + k4vy);
+        pr(IPVZ, p) = vz + dt_ / 6.0 * (k1vz + 2.0 * k2vz + 2.0 * k3vz + k4vz);
       });
-    break;}
-    case ParticlesPusher::boris_lin:
-    case ParticlesPusher::boris_tsc:
-      return PushCosmicRays(pdriver, stage);
-  default:
-    break;
-  }
 
   return TaskStatus::complete;
 }
@@ -167,148 +185,251 @@ TaskStatus Particles::Push(Driver *pdriver, int stage) {
 
 TaskStatus Particles::PushCosmicRays(Driver *pdriver, int stage) {
   auto &indcs = pmy_pack->pmesh->mb_indcs;
-  auto &size = pmy_pack->pmb->mb_size;
   auto &pi = prtcl_idata;
   auto &pr = prtcl_rdata;
   Real dt = pmy_pack->pmesh->dt;
   int gids = pmy_pack->gids;
   bool use_tsc = (pusher == ParticlesPusher::boris_tsc);
-  
+
   // Access MHD fields if available
   bool has_mhd = (pmy_pack->pmhd != nullptr);
-  DvceArray5D<Real> bcc;
-  if (has_mhd) {
-    bcc = pmy_pack->pmhd->bcc0;
+  if (!has_mhd) {
+    std::cout << "### FATAL ERROR in Particles::PushCosmicRays: "
+              << "Boris pushers require MHD fields" << std::endl;
+    return TaskStatus::fail;
   }
-  
+
+  Particles *pt = this;
+
   // Boris pusher algorithm
-  par_for("push_cr", DevExeSpace(), 0, nprtcl_thispack-1,
-  KOKKOS_LAMBDA(const int p) {
-    // Get particle properties
-    int m = pi(PGID,p) - gids;
-    Real x = pr(IPX,p);
-    Real y = pr(IPY,p);
-    Real z = (indcs.nx3 > 1) ? pr(IPZ,p) : 0.0;
-    Real vx = pr(IPVX,p);
-    Real vy = pr(IPVY,p);
-    Real vz = (indcs.nx3 > 1) ? pr(IPVZ,p) : 0.0;
-    Real q_over_m = pr(IPM,p);
-    
-    // Interpolate B-field to particle position
-    Real Bx = 0.0, By = 0.0, Bz = 0.0;
-    if (has_mhd) {
-      // Simple linear interpolation for now
-      // TODO: Add TSC interpolation option
-      Real dx1 = size.d_view(m).dx1;
-      Real dx2 = size.d_view(m).dx2;
-      Real dx3 = (indcs.nx3 > 1) ? size.d_view(m).dx3 : 1.0;
-      
-      int i = static_cast<int>((x - size.d_view(m).x1min) / dx1) + indcs.is;
-      int j = static_cast<int>((y - size.d_view(m).x2min) / dx2) + indcs.js;
-      int k = (indcs.nx3 > 1) ? 
-              static_cast<int>((z - size.d_view(m).x3min) / dx3) + indcs.ks : indcs.ks;
-      
-      // Ensure indices are within bounds
-      i = (i < indcs.is) ? indcs.is : ((i > indcs.ie) ? indcs.ie : i);
-      j = (j < indcs.js) ? indcs.js : ((j > indcs.je) ? indcs.je : j);
-      k = (k < indcs.ks) ? indcs.ks : ((k > indcs.ke) ? indcs.ke : k);
-      
-      // Simple nearest-neighbor for now
-      Bx = bcc(m,IBX,k,j,i);
-      By = bcc(m,IBY,k,j,i);
-      if (indcs.nx3 > 1) {
-        Bz = bcc(m,IBZ,k,j,i);
-      }
-    }
-    
-    // Boris algorithm
-    Real dt_half = 0.5 * dt;
-    Real qdt_2m = q_over_m * dt_half;
-    
-    // No electric field for now
-    Real Ex = 0.0, Ey = 0.0, Ez = 0.0;
-    
-    // Half electric acceleration
-    vx += qdt_2m * Ex;
-    vy += qdt_2m * Ey;
-    vz += qdt_2m * Ez;
-    
-    // Magnetic rotation
-    Real tx = qdt_2m * Bx;
-    Real ty = qdt_2m * By;
-    Real tz = qdt_2m * Bz;
-    Real t2 = tx*tx + ty*ty + tz*tz;
-    Real s = 2.0 / (1.0 + t2);
-    
-    Real vx1 = vx + vy*tz - vz*ty;
-    Real vy1 = vy + vz*tx - vx*tz;
-    Real vz1 = vz + vx*ty - vy*tx;
-    
-    vx += s*(vy1*tz - vz1*ty);
-    vy += s*(vz1*tx - vx1*tz);
-    vz += s*(vx1*ty - vy1*tx);
-    
-    // Half electric acceleration
-    vx += qdt_2m * Ex;
-    vy += qdt_2m * Ey;
-    vz += qdt_2m * Ez;
-    
-    // Update position
-    pr(IPX,p) += dt * vx;
-    pr(IPY,p) += dt * vy;
-    if (indcs.nx3 > 1) {
-      pr(IPZ,p) += dt * vz;
-    }
-    
-    // Store updated velocity
-    pr(IPVX,p) = vx;
-    pr(IPVY,p) = vy;
-    if (indcs.nx3 > 1) {
-      pr(IPVZ,p) = vz;
-    }
-    
-    // Store B-field at particle
-    pr(IPBX,p) = Bx;
-    pr(IPBY,p) = By;
-    if (indcs.nx3 > 1) {
-      pr(IPBZ,p) = Bz;
-    }
-    
-    // Update displacement tracking if enabled
-    if (track_displacement) {
-      pr(IPDX,p) += dt * vx;
-      pr(IPDY,p) += dt * vy;
-      if (indcs.nx3 > 1) {
-        pr(IPDZ,p) += dt * vz;
-      }
-      // Parallel displacement
-      Real B_mag = sqrt(Bx*Bx + By*By + Bz*Bz);
-      if (B_mag > 0.0) {
-        pr(IPDB,p) += dt * (vx*Bx + vy*By + vz*Bz) / B_mag;
-      }
-    }
-  });
-  
+  par_for(
+      "push_cr", DevExeSpace(), 0, nprtcl_thispack - 1,
+      KOKKOS_LAMBDA(const int p) {
+        // Get particle properties
+        int m = pi(PGID, p) - gids;
+        Real x = pr(IPX, p);
+        Real y = pr(IPY, p);
+        Real z = (indcs.nx3 > 1) ? pr(IPZ, p) : 0.0;
+        Real vx = pr(IPVX, p);
+        Real vy = pr(IPVY, p);
+        Real vz = (indcs.nx3 > 1) ? pr(IPVZ, p) : 0.0;
+        Real q_over_m = pr(IPM, p);
+
+        // Interpolate B-field to particle position
+        Real Bx = 0.0, By = 0.0, Bz = 0.0;
+        if (use_tsc) {
+          pt->InterpolateTSC(m, x, y, z, Bx, By, Bz);
+        } else {
+          pt->InterpolateLinear(m, x, y, z, Bx, By, Bz);
+        }
+
+        // Boris algorithm
+        Real dt_half = 0.5 * dt;
+        Real qdt_2m = q_over_m * dt_half;
+
+        // No electric field for now
+        Real Ex = 0.0, Ey = 0.0, Ez = 0.0;
+
+        // Half electric acceleration
+        vx += qdt_2m * Ex;
+        vy += qdt_2m * Ey;
+        vz += qdt_2m * Ez;
+
+        // Magnetic rotation
+        Real tx = qdt_2m * Bx;
+        Real ty = qdt_2m * By;
+        Real tz = qdt_2m * Bz;
+        Real t2 = tx * tx + ty * ty + tz * tz;
+        Real s = 2.0 / (1.0 + t2);
+
+        Real vx1 = vx + vy * tz - vz * ty;
+        Real vy1 = vy + vz * tx - vx * tz;
+        Real vz1 = vz + vx * ty - vy * tx;
+
+        vx += s * (vy1 * tz - vz1 * ty);
+        vy += s * (vz1 * tx - vx1 * tz);
+        vz += s * (vx1 * ty - vy1 * tx);
+
+        // Half electric acceleration
+        vx += qdt_2m * Ex;
+        vy += qdt_2m * Ey;
+        vz += qdt_2m * Ez;
+
+        // Update position
+        pr(IPX, p) += dt * vx;
+        pr(IPY, p) += dt * vy;
+        if (indcs.nx3 > 1) {
+          pr(IPZ, p) += dt * vz;
+        }
+
+        // Store updated velocity
+        pr(IPVX, p) = vx;
+        pr(IPVY, p) = vy;
+        if (indcs.nx3 > 1) {
+          pr(IPVZ, p) = vz;
+        }
+
+        // Store B-field at particle
+        pr(IPBX, p) = Bx;
+        pr(IPBY, p) = By;
+        if (indcs.nx3 > 1) {
+          pr(IPBZ, p) = Bz;
+        }
+
+        // Update displacement tracking if enabled
+        if (track_displacement) {
+          pr(IPDX, p) += dt * vx;
+          pr(IPDY, p) += dt * vy;
+          if (indcs.nx3 > 1) {
+            pr(IPDZ, p) += dt * vz;
+          }
+          // Parallel displacement
+          Real B_mag = sqrt(Bx * Bx + By * By + Bz * Bz);
+          if (B_mag > 0.0) {
+            pr(IPDB, p) += dt * (vx * Bx + vy * By + vz * Bz) / B_mag;
+          }
+        }
+      });
+
   return TaskStatus::complete;
 }
 
-//----------------------------------------------------------------------------------------
-//! \fn void Particles::PushStars
-//  \brief Separate method for star particle dynamics
+KOKKOS_INLINE_FUNCTION
+void Particles::InterpolateLinear(int m, Real x, Real y, Real z, Real &Bx, Real &By,
+                                  Real &Bz) const {
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  auto &size = pmy_pack->pmb->mb_size;
+  auto bcc = pmy_pack->pmhd->bcc0;
 
-TaskStatus Particles::PushStars(Driver *pdriver, int stage) {
-  // For now, just call the RK4 gravity pusher code
-  // This is a placeholder for future star-specific dynamics
-  return Push(pdriver, stage);
+  Real dx1 = size.d_view(m).dx1;
+  Real dx2 = size.d_view(m).dx2;
+  Real dx3 = (indcs.nx3 > 1) ? size.d_view(m).dx3 : 1.0;
+
+  Real fx = (x - size.d_view(m).x1min) / dx1;
+  Real fy = (y - size.d_view(m).x2min) / dx2;
+  Real fz = (indcs.nx3 > 1) ? (z - size.d_view(m).x3min) / dx3 : 0.0;
+
+  int i0 = static_cast<int>(floor(fx)) + indcs.is;
+  int j0 = static_cast<int>(floor(fy)) + indcs.js;
+  int k0 = (indcs.nx3 > 1) ? static_cast<int>(floor(fz)) + indcs.ks : indcs.ks;
+
+  i0 = (i0 < indcs.is) ? indcs.is : ((i0 > indcs.ie - 1) ? indcs.ie - 1 : i0);
+  j0 = (j0 < indcs.js) ? indcs.js : ((j0 > indcs.je - 1) ? indcs.je - 1 : j0);
+  k0 = (k0 < indcs.ks) ? indcs.ks : ((k0 > indcs.ke - 1) ? indcs.ke - 1 : k0);
+
+  int i1 = i0 + 1;
+  int j1 = j0 + 1;
+  int k1 = (indcs.nx3 > 1) ? k0 + 1 : k0;
+
+  Real wx = fx - floor(fx);
+  Real wy = fy - floor(fy);
+  Real wz = (indcs.nx3 > 1) ? fz - floor(fz) : 0.0;
+
+  Bx = By = Bz = 0.0;
+
+  for (int dk = 0; dk <= (indcs.nx3 > 1 ? 1 : 0); ++dk) {
+    Real wk = (indcs.nx3 > 1) ? (dk == 0 ? (1.0 - wz) : wz) : 1.0;
+    int kk = (dk == 0) ? k0 : k1;
+    for (int dj = 0; dj <= 1; ++dj) {
+      Real wj = (dj == 0) ? (1.0 - wy) : wy;
+      int jj = (dj == 0) ? j0 : j1;
+      for (int di = 0; di <= 1; ++di) {
+        Real wi = (di == 0) ? (1.0 - wx) : wx;
+        int ii = (di == 0) ? i0 : i1;
+        Real w = wi * wj * wk;
+        Bx += w * bcc(m, IBX, kk, jj, ii);
+        By += w * bcc(m, IBY, kk, jj, ii);
+        if (indcs.nx3 > 1) {
+          Bz += w * bcc(m, IBZ, kk, jj, ii);
+        }
+      }
+    }
+  }
+  if (indcs.nx3 == 1) {
+    Bz = 0.0;
+  }
 }
 
 KOKKOS_INLINE_FUNCTION
-Real GravPot(Real x1, Real x2, Real x3,
-             Real G, Real r_s, Real rho_s,
-             Real M_gal, Real a_gal, Real z_gal,
-             Real R200, Real rho_mean) {
-  Real R = sqrt(x1*x1 + x2*x2);
-  Real r2 = x1*x1 + x2*x2 + x3*x3;
+void Particles::InterpolateTSC(int m, Real x, Real y, Real z, Real &Bx, Real &By,
+                               Real &Bz) const {
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  auto &size = pmy_pack->pmb->mb_size;
+  auto bcc = pmy_pack->pmhd->bcc0;
+
+  Real dx1 = size.d_view(m).dx1;
+  Real dx2 = size.d_view(m).dx2;
+  Real dx3 = (indcs.nx3 > 1) ? size.d_view(m).dx3 : 1.0;
+
+  Real fx = (x - size.d_view(m).x1min) / dx1 - 0.5;
+  Real fy = (y - size.d_view(m).x2min) / dx2 - 0.5;
+  Real fz = (indcs.nx3 > 1) ? (z - size.d_view(m).x3min) / dx3 - 0.5 : 0.0;
+
+  int ic = static_cast<int>(floor(fx)) + indcs.is;
+  int jc = static_cast<int>(floor(fy)) + indcs.js;
+  int kc = (indcs.nx3 > 1) ? static_cast<int>(floor(fz)) + indcs.ks : indcs.ks;
+
+  Real di = fx - floor(fx);
+  Real dj = fy - floor(fy);
+  Real dk = (indcs.nx3 > 1) ? fz - floor(fz) : 0.0;
+
+  auto weight = [](Real d) {
+    Real ad = fabs(d);
+    if (ad < 0.5) return 0.75 - ad * ad;
+    if (ad < 1.5) {
+      Real t = 1.5 - ad;
+      return 0.5 * t * t;
+    }
+    return 0.0;
+  };
+
+  Real wx[3] = {weight(di + 1.0), weight(di), weight(di - 1.0)};
+  Real wy[3] = {weight(dj + 1.0), weight(dj), weight(dj - 1.0)};
+  Real wz[3] = {0.0, 1.0, 0.0};
+  int kz[3] = {kc, kc, kc};
+  if (indcs.nx3 > 1) {
+    wz[0] = weight(dk + 1.0);
+    wz[1] = weight(dk);
+    wz[2] = weight(dk - 1.0);
+    kz[0] = kc - 1;
+    kz[1] = kc;
+    kz[2] = kc + 1;
+  }
+
+  int ix[3] = {ic - 1, ic, ic + 1};
+  int iy[3] = {jc - 1, jc, jc + 1};
+  for (int n = 0; n < 3; ++n) {
+    ix[n] = (ix[n] < indcs.is) ? indcs.is : ((ix[n] > indcs.ie) ? indcs.ie : ix[n]);
+    iy[n] = (iy[n] < indcs.js) ? indcs.js : ((iy[n] > indcs.je) ? indcs.je : iy[n]);
+    if (indcs.nx3 > 1) {
+      kz[n] = (kz[n] < indcs.ks) ? indcs.ks : ((kz[n] > indcs.ke) ? indcs.ke : kz[n]);
+    }
+  }
+
+  Bx = By = Bz = 0.0;
+  int nk = (indcs.nx3 > 1) ? 3 : 1;
+  for (int kk = 0; kk < nk; ++kk) {
+    for (int jj = 0; jj < 3; ++jj) {
+      for (int ii = 0; ii < 3; ++ii) {
+        Real w = wx[ii] * wy[jj] * wz[kk];
+        Bx += w * bcc(m, IBX, kz[kk], iy[jj], ix[ii]);
+        By += w * bcc(m, IBY, kz[kk], iy[jj], ix[ii]);
+        if (indcs.nx3 > 1) {
+          Bz += w * bcc(m, IBZ, kz[kk], iy[jj], ix[ii]);
+        }
+      }
+    }
+  }
+  if (indcs.nx3 == 1) {
+    Bz = 0.0;
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+Real GravPot(Real x1, Real x2, Real x3, Real G, Real r_s, Real rho_s,
+             Real M_gal, Real a_gal, Real z_gal, Real R200, Real rho_mean) {
+  Real R = sqrt(x1 * x1 + x2 * x2);
+  Real r2 = x1 * x1 + x2 * x2 + x3 * x3;
   Real r = sqrt(r2);
 
   // Avoid division by zero
@@ -320,7 +441,8 @@ Real GravPot(Real x1, Real x2, Real x3,
   Real phi_NFW = -4 * M_PI * G * rho_s * SQR(r_s) * log(1 + x) / x;
 
   // Miyamoto-Nagai model
-  Real phi_MN = -G * M_gal / sqrt(R*R + SQR(sqrt(x3*x3 + z_gal*z_gal) + a_gal));
+  Real phi_MN =
+      -G * M_gal / sqrt(R * R + SQR(sqrt(x3 * x3 + z_gal * z_gal) + a_gal));
 
   // Outer component
   Real term1 = (4.0 / 3.0) * pow(5 * R200, 1.5) * sqrt(r);


### PR DESCRIPTION
## Summary
- Implement linear and TSC magnetic-field interpolation for cosmic-ray pushers
- Randomize or center particle seeding with safe distribution across meshblocks
- Clean up particle boundary resources and enforce MHD presence for Boris pushers
- Ensure particle arrays are sized for all index constants and free MPI communicators

## Testing
- `cmake -S . -B build` *(fails: The source directory /workspace/athenak/kokkos does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c44729c48324a654e8bc476f696b