### PR TITLE
Fix deep-AMR face-centered divB preservation

### DIFF
--- a/inputs/tests/divb_amr_1d.athinput
+++ b/inputs/tests/divb_amr_1d.athinput
@@ -1,0 +1,74 @@
+# AthenaK input file for AMR div(B) preservation in 1D
+
+<job>
+basename  = DivBAMR1D
+
+<mesh>
+nghost    = 2
+nx1       = 64
+x1min     = 0.0
+x1max     = 1.0
+ix1_bc    = periodic
+ox1_bc    = periodic
+
+nx2       = 1
+x2min     = 0.0
+x2max     = 1.0
+ix2_bc    = periodic
+ox2_bc    = periodic
+
+nx3       = 1
+x3min     = 0.0
+x3max     = 1.0
+ix3_bc    = periodic
+ox3_bc    = periodic
+
+<meshblock>
+nx1       = 8
+nx2       = 1
+nx3       = 1
+
+<mesh_refinement>
+refinement          = adaptive
+num_levels          = 3
+ncycle_check        = 1
+refinement_interval = 1
+max_nmb_per_rank    = 256
+
+<amr_criterion1>
+method = user
+
+<time>
+evolution  = dynamic
+integrator = rk2
+cfl_number = 0.25
+nlim       = 24
+tlim       = 1.0
+ndiag      = 1
+
+<mhd>
+eos         = ideal
+reconstruct = plm
+rsolver     = hlld
+gamma       = 1.66666666667
+
+<problem>
+pgen_name     = divb_amr
+user_hist     = true
+refine_levels = 2
+rho0          = 1.0
+pgas0         = 10.0
+vx0           = 0.08
+vy0           = 0.05
+vz0           = 0.03
+guide_b1      = 0.7
+guide_b2      = 0.2
+guide_b3      = -0.15
+field_amp     = 0.25
+field_k       = 2.0
+
+<output1>
+file_type      = hst
+data_format    = %24.16e
+dcycle         = 1
+user_hist_only = true

--- a/inputs/tests/divb_amr_2d.athinput
+++ b/inputs/tests/divb_amr_2d.athinput
@@ -1,0 +1,74 @@
+# AthenaK input file for AMR div(B) preservation in 2D
+
+<job>
+basename  = DivBAMR2D
+
+<mesh>
+nghost    = 2
+nx1       = 48
+x1min     = 0.0
+x1max     = 1.0
+ix1_bc    = periodic
+ox1_bc    = periodic
+
+nx2       = 48
+x2min     = 0.0
+x2max     = 1.0
+ix2_bc    = periodic
+ox2_bc    = periodic
+
+nx3       = 1
+x3min     = 0.0
+x3max     = 1.0
+ix3_bc    = periodic
+ox3_bc    = periodic
+
+<meshblock>
+nx1       = 8
+nx2       = 8
+nx3       = 1
+
+<mesh_refinement>
+refinement          = adaptive
+num_levels          = 3
+ncycle_check        = 1
+refinement_interval = 1
+max_nmb_per_rank    = 1024
+
+<amr_criterion1>
+method = user
+
+<time>
+evolution  = dynamic
+integrator = rk2
+cfl_number = 0.25
+nlim       = 20
+tlim       = 1.0
+ndiag      = 1
+
+<mhd>
+eos         = ideal
+reconstruct = plm
+rsolver     = hlld
+gamma       = 1.66666666667
+
+<problem>
+pgen_name     = divb_amr
+user_hist     = true
+refine_levels = 2
+rho0          = 1.0
+pgas0         = 10.0
+vx0           = 0.08
+vy0           = 0.05
+vz0           = 0.03
+guide_b1      = 0.7
+guide_b2      = 0.2
+guide_b3      = -0.15
+field_amp     = 0.25
+field_k       = 2.0
+
+<output1>
+file_type      = hst
+data_format    = %24.16e
+dcycle         = 1
+user_hist_only = true

--- a/inputs/tests/divb_amr_3d.athinput
+++ b/inputs/tests/divb_amr_3d.athinput
@@ -1,0 +1,74 @@
+# AthenaK input file for AMR div(B) preservation in 3D
+
+<job>
+basename  = DivBAMR3D
+
+<mesh>
+nghost    = 2
+nx1       = 32
+x1min     = 0.0
+x1max     = 1.0
+ix1_bc    = periodic
+ox1_bc    = periodic
+
+nx2       = 32
+x2min     = 0.0
+x2max     = 1.0
+ix2_bc    = periodic
+ox2_bc    = periodic
+
+nx3       = 32
+x3min     = 0.0
+x3max     = 1.0
+ix3_bc    = periodic
+ox3_bc    = periodic
+
+<meshblock>
+nx1       = 8
+nx2       = 8
+nx3       = 8
+
+<mesh_refinement>
+refinement          = adaptive
+num_levels          = 3
+ncycle_check        = 1
+refinement_interval = 1
+max_nmb_per_rank    = 2048
+
+<amr_criterion1>
+method = user
+
+<time>
+evolution  = dynamic
+integrator = rk2
+cfl_number = 0.25
+nlim       = 12
+tlim       = 1.0
+ndiag      = 1
+
+<mhd>
+eos         = ideal
+reconstruct = plm
+rsolver     = hlld
+gamma       = 1.66666666667
+
+<problem>
+pgen_name     = divb_amr
+user_hist     = true
+refine_levels = 2
+rho0          = 1.0
+pgas0         = 10.0
+vx0           = 0.08
+vy0           = 0.05
+vz0           = 0.03
+guide_b1      = 0.7
+guide_b2      = 0.2
+guide_b3      = -0.15
+field_amp     = 0.25
+field_k       = 2.0
+
+<output1>
+file_type      = hst
+data_format    = %24.16e
+dcycle         = 1
+user_hist_only = true

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,7 @@ add_executable(
         pgen/tests/collapse.cpp
         pgen/tests/cpaw.cpp
         pgen/tests/cshock.cpp
+        pgen/tests/divb_amr.cpp
         pgen/tests/diffusion.cpp
         pgen/tests/gr_bondi.cpp
         pgen/tests/gr_monopole.cpp

--- a/src/bvals/bvals_fc.cpp
+++ b/src/bvals/bvals_fc.cpp
@@ -8,6 +8,7 @@
 //! Mesh variables.
 //! Prolongation of FC variables  occurs in ProlongateFC() function called from task list
 
+#include <cstdio>
 #include <cstdlib>
 #include <iostream>
 #include <utility>
@@ -18,6 +19,28 @@
 #include "parameter_input.hpp"
 #include "mesh/mesh.hpp"
 #include "bvals.hpp"
+
+namespace {
+
+KOKKOS_INLINE_FUNCTION
+bool IsActiveFCFace(const int v, const int k, const int j, const int i,
+                    const RegionIndcs &indcs) {
+  if (v == 0) {
+    return (i >= indcs.is) && (i <= indcs.ie + 1) &&
+           (j >= indcs.js) && (j <= indcs.je) &&
+           (k >= indcs.ks) && (k <= indcs.ke);
+  } else if (v == 1) {
+    return (i >= indcs.is) && (i <= indcs.ie) &&
+           (j >= indcs.js) && (j <= indcs.je + 1) &&
+           (k >= indcs.ks) && (k <= indcs.ke);
+  } else {
+    return (i >= indcs.is) && (i <= indcs.ie) &&
+           (j >= indcs.js) && (j <= indcs.je) &&
+           (k >= indcs.ks) && (k <= indcs.ke + 1);
+  }
+}
+
+} // namespace
 
 //----------------------------------------------------------------------------------------
 // BValFC constructor:
@@ -239,6 +262,7 @@ TaskStatus MeshBoundaryValuesFC::RecvAndUnpackFC(DvceFaceFld4D<Real> &b,
   int nnghbr = pmy_pack->pmb->nnghbr;
   auto &nghbr = pmy_pack->pmb->nghbr;
   auto &rbuf = recvbuf;
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
 #if MPI_PARALLEL_ENABLED
   //----- STEP 1: check that recv boundary buffer communications have all completed
 
@@ -326,6 +350,15 @@ TaskStatus MeshBoundaryValuesFC::RecvAndUnpackFC(DvceFaceFld4D<Real> &b,
             int i = (idx - k*nji - j*ni) + il;
             k += kl;
             j += jl;
+            if (IsActiveFCFace(v, k, j, i, indcs)) {
+#ifdef ATHENAK_DEBUG_FC_AMR_OWNERSHIP
+              Kokkos::printf("FC AMR ownership blocked recv m=%d n=%d v=%d "
+                             "kji=(%d,%d,%d) nlev=%d mlev=%d\n",
+                             m, n, v, k, j, i, nghbr.d_view(m,n).lev,
+                             mblev.d_view(m));
+#endif
+              return;
+            }
             if (v==0) {
               b.x1f(m,k,j,i) = rbuf[n].vars(m,i-il + ni*(j-jl + nj*(k-kl)));
             } else if (v==1) {

--- a/src/bvals/prolongation.cpp
+++ b/src/bvals/prolongation.cpp
@@ -8,6 +8,7 @@
 //! variables. Functions are members of MeshBoundaryValuesCC or MeshBoundaryValuesFC
 //! classes.
 
+#include <cstdio>
 #include <cstdlib>
 #include <iostream>
 #include <iomanip>    // std::setprecision()
@@ -15,11 +16,354 @@
 #include "athena.hpp"
 #include "parameter_input.hpp"
 #include "mesh/mesh.hpp"
+#include "mesh/nghbr_index.hpp"
 #include "bvals.hpp"
 #include "mesh/prolongation.hpp" // implements prolongation operators
 #include "mesh/restriction.hpp" // implements restriction operators
 
 #include "coordinates/cell_locations.hpp"
+
+namespace {
+
+KOKKOS_INLINE_FUNCTION
+void NeighborOffsetFromIndex(const int n, int &ox1, int &ox2, int &ox3) {
+  ox1 = 0;
+  ox2 = 0;
+  ox3 = 0;
+  for (int iz = -1; iz <= 1; ++iz) {
+    for (int iy = -1; iy <= 1; ++iy) {
+      for (int ix = -1; ix <= 1; ++ix) {
+        if ((ix == 0) && (iy == 0) && (iz == 0)) continue;
+        for (int n1 = 0; n1 <= 1; ++n1) {
+          for (int n2 = 0; n2 <= 1; ++n2) {
+            if (NeighborIndex(ix, iy, iz, n1, n2) == n) {
+              ox1 = ix;
+              ox2 = iy;
+              ox3 = iz;
+              return;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+int MaxNeighborLevelAtOffset(const int m, const int nnghbr, const int ox1,
+                             const int ox2, const int ox3,
+                             const DualArray2D<NeighborBlock> &nghbr) {
+  int max_lev = -1;
+  for (int n1 = 0; n1 <= 1; ++n1) {
+    for (int n2 = 0; n2 <= 1; ++n2) {
+      const int idx = NeighborIndex(ox1, ox2, ox3, n1, n2);
+      if ((idx >= 0) && (idx < nnghbr) && (nghbr.d_view(m, idx).gid >= 0)) {
+        max_lev =
+            (nghbr.d_view(m, idx).lev > max_lev) ? nghbr.d_view(m, idx).lev : max_lev;
+      }
+    }
+  }
+  return max_lev;
+}
+
+KOKKOS_INLINE_FUNCTION
+bool IsActiveFCFace(const int v, const int k, const int j, const int i,
+                    const RegionIndcs &indcs) {
+  if (v == 0) {
+    return (i >= indcs.is) && (i <= indcs.ie + 1) &&
+           (j >= indcs.js) && (j <= indcs.je) &&
+           (k >= indcs.ks) && (k <= indcs.ke);
+  } else if (v == 1) {
+    return (i >= indcs.is) && (i <= indcs.ie) &&
+           (j >= indcs.js) && (j <= indcs.je + 1) &&
+           (k >= indcs.ks) && (k <= indcs.ke);
+  } else {
+    return (i >= indcs.is) && (i <= indcs.ie) &&
+           (j >= indcs.js) && (j <= indcs.je) &&
+           (k >= indcs.ks) && (k <= indcs.ke + 1);
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+bool CanProlongateFCFace(const int m, const int nnghbr, const int v,
+                         const int k, const int j, const int i,
+                         const int ox1, const int ox2, const int ox3,
+                         const int my_lev, const RegionIndcs &indcs,
+                         const DualArray2D<NeighborBlock> &nghbr) {
+  if (!IsActiveFCFace(v, k, j, i, indcs)) {
+    return true;
+  }
+
+  // Coarse-neighbor prolongation may write active faces only at the physical
+  // fine/coarse interface normal to the face component. Active interior faces and active
+  // boundary faces owned by same-level or finer neighbors are left untouched.
+  if (v == 0) {
+    int normal_ox = 0;
+    if (i == indcs.is) {
+      normal_ox = -1;
+    } else if (i == indcs.ie + 1) {
+      normal_ox = 1;
+    } else {
+      return false;
+    }
+    return (ox1 == normal_ox) && (ox2 == 0) && (ox3 == 0) &&
+           (MaxNeighborLevelAtOffset(m, nnghbr, normal_ox, 0, 0, nghbr) < my_lev);
+  } else if (v == 1) {
+    int normal_ox = 0;
+    if (j == indcs.js) {
+      normal_ox = -1;
+    } else if (j == indcs.je + 1) {
+      normal_ox = 1;
+    } else {
+      return false;
+    }
+    return (ox1 == 0) && (ox2 == normal_ox) && (ox3 == 0) &&
+           (MaxNeighborLevelAtOffset(m, nnghbr, 0, normal_ox, 0, nghbr) < my_lev);
+  } else {
+    int normal_ox = 0;
+    if (k == indcs.ks) {
+      normal_ox = -1;
+    } else if (k == indcs.ke + 1) {
+      normal_ox = 1;
+    } else {
+      return false;
+    }
+    return (ox1 == 0) && (ox2 == 0) && (ox3 == normal_ox) &&
+           (MaxNeighborLevelAtOffset(m, nnghbr, 0, 0, normal_ox, nghbr) < my_lev);
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+void StoreProlongatedFCFace(const int writer, const int m, const int nnghbr,
+                            const int v, const int k, const int j, const int i,
+                            const int ox1, const int ox2, const int ox3,
+                            const int my_lev, const RegionIndcs &indcs,
+                            const DualArray2D<NeighborBlock> &nghbr,
+                            const Real value, const DvceArray4D<Real> &bf) {
+  if (CanProlongateFCFace(m, nnghbr, v, k, j, i, ox1, ox2, ox3,
+                          my_lev, indcs, nghbr)) {
+    bf(m,k,j,i) = value;
+#ifdef ATHENAK_DEBUG_FC_AMR_OWNERSHIP
+  } else {
+    Kokkos::printf("FC AMR ownership blocked writer=%d m=%d v=%d kji=(%d,%d,%d) "
+                   "ox=(%d,%d,%d) lev=%d\n",
+                   writer, m, v, k, j, i, ox1, ox2, ox3, my_lev);
+#endif
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+void ProlongFCSharedX1FaceOwned(const int m, const int nnghbr,
+                                const int k, const int j, const int i,
+                                const int fk, const int fj, const int fi,
+                                const int ox1, const int ox2, const int ox3,
+                                const int my_lev, const bool multi_d,
+                                const bool three_d, const RegionIndcs &indcs,
+                                const DualArray2D<NeighborBlock> &nghbr,
+                                const DvceArray4D<Real> &cbx1f,
+                                const DvceArray4D<Real> &bx1f) {
+  Real dvar2 = 0.0;
+  if (multi_d) {
+    Real dl = cbx1f(m,k,j  ,i) - cbx1f(m,k,j-1,i);
+    Real dr = cbx1f(m,k,j+1,i) - cbx1f(m,k,j  ,i);
+    dvar2 = 0.125*(SIGN(dl) + SIGN(dr))*fmin(fabs(dl), fabs(dr));
+  }
+
+  Real dvar3 = 0.0;
+  if (three_d) {
+    Real dl = cbx1f(m,k  ,j,i) - cbx1f(m,k-1,j,i);
+    Real dr = cbx1f(m,k+1,j,i) - cbx1f(m,k  ,j,i);
+    dvar3 = 0.125*(SIGN(dl) + SIGN(dr))*fmin(fabs(dl), fabs(dr));
+  }
+
+  StoreProlongatedFCFace(1, m, nnghbr, 0, fk, fj, fi, ox1, ox2, ox3,
+                         my_lev, indcs, nghbr, cbx1f(m,k,j,i) - dvar2 - dvar3, bx1f);
+  if (multi_d) {
+    StoreProlongatedFCFace(1, m, nnghbr, 0, fk, fj+1, fi, ox1, ox2, ox3,
+                           my_lev, indcs, nghbr, cbx1f(m,k,j,i) + dvar2 - dvar3, bx1f);
+  }
+  if (three_d) {
+    StoreProlongatedFCFace(1, m, nnghbr, 0, fk+1, fj, fi, ox1, ox2, ox3,
+                           my_lev, indcs, nghbr, cbx1f(m,k,j,i) - dvar2 + dvar3, bx1f);
+    StoreProlongatedFCFace(1, m, nnghbr, 0, fk+1, fj+1, fi, ox1, ox2, ox3,
+                           my_lev, indcs, nghbr, cbx1f(m,k,j,i) + dvar2 + dvar3, bx1f);
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+void ProlongFCSharedX2FaceOwned(const int m, const int nnghbr,
+                                const int k, const int j, const int i,
+                                const int fk, const int fj, const int fi,
+                                const int ox1, const int ox2, const int ox3,
+                                const int my_lev, const bool three_d,
+                                const RegionIndcs &indcs,
+                                const DualArray2D<NeighborBlock> &nghbr,
+                                const DvceArray4D<Real> &cbx2f,
+                                const DvceArray4D<Real> &bx2f) {
+  Real dl = cbx2f(m,k,j,i  ) - cbx2f(m,k,j,i-1);
+  Real dr = cbx2f(m,k,j,i+1) - cbx2f(m,k,j,i  );
+  Real dvar1 = 0.125*(SIGN(dl) + SIGN(dr))*fmin(fabs(dl), fabs(dr));
+
+  Real dvar3 = 0.0;
+  if (three_d) {
+    dl = cbx2f(m,k  ,j,i) - cbx2f(m,k-1,j,i);
+    dr = cbx2f(m,k+1,j,i) - cbx2f(m,k  ,j,i);
+    dvar3 = 0.125*(SIGN(dl) + SIGN(dr))*fmin(fabs(dl), fabs(dr));
+  }
+
+  StoreProlongatedFCFace(1, m, nnghbr, 1, fk, fj, fi, ox1, ox2, ox3,
+                         my_lev, indcs, nghbr, cbx2f(m,k,j,i) - dvar1 - dvar3, bx2f);
+  StoreProlongatedFCFace(1, m, nnghbr, 1, fk, fj, fi+1, ox1, ox2, ox3,
+                         my_lev, indcs, nghbr, cbx2f(m,k,j,i) + dvar1 - dvar3, bx2f);
+  if (three_d) {
+    StoreProlongatedFCFace(1, m, nnghbr, 1, fk+1, fj, fi, ox1, ox2, ox3,
+                           my_lev, indcs, nghbr, cbx2f(m,k,j,i) - dvar1 + dvar3, bx2f);
+    StoreProlongatedFCFace(1, m, nnghbr, 1, fk+1, fj, fi+1, ox1, ox2, ox3,
+                           my_lev, indcs, nghbr, cbx2f(m,k,j,i) + dvar1 + dvar3, bx2f);
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+void ProlongFCSharedX3FaceOwned(const int m, const int nnghbr,
+                                const int k, const int j, const int i,
+                                const int fk, const int fj, const int fi,
+                                const int ox1, const int ox2, const int ox3,
+                                const int my_lev, const bool multi_d,
+                                const RegionIndcs &indcs,
+                                const DualArray2D<NeighborBlock> &nghbr,
+                                const DvceArray4D<Real> &cbx3f,
+                                const DvceArray4D<Real> &bx3f) {
+  Real dl = cbx3f(m,k,j,i  ) - cbx3f(m,k,j,i-1);
+  Real dr = cbx3f(m,k,j,i+1) - cbx3f(m,k,j,i  );
+  Real dvar1 = 0.125*(SIGN(dl) + SIGN(dr))*fmin(fabs(dl), fabs(dr));
+
+  Real dvar2 = 0.0;
+  if (multi_d) {
+    dl = cbx3f(m,k,j  ,i) - cbx3f(m,k,j-1,i);
+    dr = cbx3f(m,k,j+1,i) - cbx3f(m,k,j  ,i);
+    dvar2 = 0.125*(SIGN(dl) + SIGN(dr))*fmin(fabs(dl), fabs(dr));
+  }
+
+  StoreProlongatedFCFace(1, m, nnghbr, 2, fk, fj, fi, ox1, ox2, ox3,
+                         my_lev, indcs, nghbr, cbx3f(m,k,j,i) - dvar1 - dvar2, bx3f);
+  StoreProlongatedFCFace(1, m, nnghbr, 2, fk, fj, fi+1, ox1, ox2, ox3,
+                         my_lev, indcs, nghbr, cbx3f(m,k,j,i) + dvar1 - dvar2, bx3f);
+  if (multi_d) {
+    StoreProlongatedFCFace(1, m, nnghbr, 2, fk, fj+1, fi, ox1, ox2, ox3,
+                           my_lev, indcs, nghbr, cbx3f(m,k,j,i) - dvar1 + dvar2, bx3f);
+    StoreProlongatedFCFace(1, m, nnghbr, 2, fk, fj+1, fi+1, ox1, ox2, ox3,
+                           my_lev, indcs, nghbr, cbx3f(m,k,j,i) + dvar1 + dvar2, bx3f);
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+void ProlongFCInternalOwned(const int m, const int nnghbr, const int fk, const int fj,
+                            const int fi, const int ox1, const int ox2, const int ox3,
+                            const int my_lev, const bool three_d,
+                            const RegionIndcs &indcs,
+                            const DualArray2D<NeighborBlock> &nghbr,
+                            const DvceFaceFld4D<Real> &b) {
+  if (three_d) {
+    Real Uxx  = 0.0, Vyy  = 0.0, Wzz  = 0.0;
+    Real Uxyz = 0.0, Vxyz = 0.0, Wxyz = 0.0;
+    for (int jj=0; jj<2; jj++) {
+      int jsgn = 2*jj - 1;
+      int fjj  = fj + jj, fjp = fj + 2*jj;
+      for (int ii=0; ii<2; ii++) {
+        int isgn = 2*ii - 1;
+        int fii = fi + ii, fip = fi + 2*ii;
+        Uxx += isgn*(jsgn*(b.x2f(m,fk  ,fjp,fii) + b.x2f(m,fk+1,fjp,fii)) +
+                          (b.x3f(m,fk+2,fjj,fii) - b.x3f(m,fk  ,fjj,fii)));
+
+        Vyy += jsgn*(     (b.x3f(m,fk+2,fjj,fii) - b.x3f(m,fk  ,fjj,fii)) +
+                     isgn*(b.x1f(m,fk  ,fjj,fip) + b.x1f(m,fk+1,fjj,fip)));
+
+        Wzz +=       isgn*(b.x1f(m,fk+1,fjj,fip) - b.x1f(m,fk  ,fjj,fip)) +
+                     jsgn*(b.x2f(m,fk+1,fjp,fii) - b.x2f(m,fk  ,fjp,fii));
+
+        Uxyz += isgn*jsgn*(b.x1f(m,fk+1,fjj,fip) - b.x1f(m,fk  ,fjj,fip));
+        Vxyz += isgn*jsgn*(b.x2f(m,fk+1,fjp,fii) - b.x2f(m,fk  ,fjp,fii));
+        Wxyz += isgn*jsgn*(b.x3f(m,fk+2,fjj,fii) - b.x3f(m,fk  ,fjj,fii));
+      }
+    }
+    Uxx *= 0.125;  Vyy *= 0.125;  Wzz *= 0.125;
+    Uxyz *= 0.0625; Vxyz *= 0.0625; Wxyz *= 0.0625;
+
+    StoreProlongatedFCFace(2, m, nnghbr, 0, fk, fj, fi+1, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x1f(m,fk,fj,fi) + b.x1f(m,fk,fj,fi+2))
+                           + Uxx - Vxyz - Wxyz, b.x1f);
+    StoreProlongatedFCFace(2, m, nnghbr, 0, fk, fj+1, fi+1, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x1f(m,fk,fj+1,fi) + b.x1f(m,fk,fj+1,fi+2))
+                           + Uxx - Vxyz + Wxyz, b.x1f);
+    StoreProlongatedFCFace(2, m, nnghbr, 0, fk+1, fj, fi+1, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x1f(m,fk+1,fj,fi) + b.x1f(m,fk+1,fj,fi+2))
+                           + Uxx + Vxyz - Wxyz, b.x1f);
+    StoreProlongatedFCFace(2, m, nnghbr, 0, fk+1, fj+1, fi+1, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x1f(m,fk+1,fj+1,fi) + b.x1f(m,fk+1,fj+1,fi+2))
+                           + Uxx + Vxyz + Wxyz, b.x1f);
+
+    StoreProlongatedFCFace(2, m, nnghbr, 1, fk, fj+1, fi, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x2f(m,fk,fj,fi) + b.x2f(m,fk,fj+2,fi))
+                           + Vyy - Uxyz - Wxyz, b.x2f);
+    StoreProlongatedFCFace(2, m, nnghbr, 1, fk, fj+1, fi+1, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x2f(m,fk,fj,fi+1) + b.x2f(m,fk,fj+2,fi+1))
+                           + Vyy - Uxyz + Wxyz, b.x2f);
+    StoreProlongatedFCFace(2, m, nnghbr, 1, fk+1, fj+1, fi, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x2f(m,fk+1,fj,fi) + b.x2f(m,fk+1,fj+2,fi))
+                           + Vyy + Uxyz - Wxyz, b.x2f);
+    StoreProlongatedFCFace(2, m, nnghbr, 1, fk+1, fj+1, fi+1, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x2f(m,fk+1,fj,fi+1) + b.x2f(m,fk+1,fj+2,fi+1))
+                           + Vyy + Uxyz + Wxyz, b.x2f);
+
+    StoreProlongatedFCFace(2, m, nnghbr, 2, fk+1, fj, fi, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x3f(m,fk+2,fj,fi) + b.x3f(m,fk,fj,fi))
+                           + Wzz - Uxyz - Vxyz, b.x3f);
+    StoreProlongatedFCFace(2, m, nnghbr, 2, fk+1, fj, fi+1, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x3f(m,fk+2,fj,fi+1) + b.x3f(m,fk,fj,fi+1))
+                           + Wzz - Uxyz + Vxyz, b.x3f);
+    StoreProlongatedFCFace(2, m, nnghbr, 2, fk+1, fj+1, fi, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x3f(m,fk+2,fj+1,fi) + b.x3f(m,fk,fj+1,fi))
+                           + Wzz + Uxyz - Vxyz, b.x3f);
+    StoreProlongatedFCFace(2, m, nnghbr, 2, fk+1, fj+1, fi+1, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x3f(m,fk+2,fj+1,fi+1) + b.x3f(m,fk,fj+1,fi+1))
+                           + Wzz + Uxyz + Vxyz, b.x3f);
+  } else {
+    Real tmp1 = 0.25*(b.x2f(m,fk,fj+2,fi+1) - b.x2f(m,fk,fj,  fi+1)
+                    - b.x2f(m,fk,fj+2,fi  ) + b.x2f(m,fk,fj,  fi  ));
+    Real tmp2 = 0.25*(b.x1f(m,fk,fj,  fi  ) - b.x1f(m,fk,fj,  fi+2)
+                    - b.x1f(m,fk,fj+1,fi  ) + b.x1f(m,fk,fj+1,fi+2));
+    StoreProlongatedFCFace(2, m, nnghbr, 0, fk, fj, fi+1, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x1f(m,fk,fj,fi) + b.x1f(m,fk,fj,fi+2)) + tmp1,
+                           b.x1f);
+    StoreProlongatedFCFace(2, m, nnghbr, 0, fk, fj+1, fi+1, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x1f(m,fk,fj+1,fi) + b.x1f(m,fk,fj+1,fi+2)) + tmp1,
+                           b.x1f);
+    StoreProlongatedFCFace(2, m, nnghbr, 1, fk, fj+1, fi, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x2f(m,fk,fj,fi) + b.x2f(m,fk,fj+2,fi)) + tmp2,
+                           b.x2f);
+    StoreProlongatedFCFace(2, m, nnghbr, 1, fk, fj+1, fi+1, ox1, ox2, ox3, my_lev,
+                           indcs, nghbr,
+                           0.5*(b.x2f(m,fk,fj,fi+1) + b.x2f(m,fk,fj+2,fi+1)) + tmp2,
+                           b.x2f);
+  }
+}
+
+} // namespace
 //----------------------------------------------------------------------------------------
 //! \fn void FillCoarseInBndryCC()
 //! \brief To ensure that the coarse array is up-to-date in all neighboring cells touched
@@ -338,6 +682,10 @@ void MeshBoundaryValuesFC::ProlongateFC(DvceFaceFld4D<Real> &b, DvceFaceFld4D<Re
 
     // only prolongate when neighbor exists and is at coarser level
     if ((nghbr.d_view(m,n).gid >= 0) && (nghbr.d_view(m,n).lev < mblev.d_view(m))) {
+      int ox1, ox2, ox3;
+      NeighborOffsetFromIndex(n, ox1, ox2, ox3);
+      const int my_lev = mblev.d_view(m);
+
       int il = rbuf[n].iprol[v].bis;
       int iu = rbuf[n].iprol[v].bie;
       int jl = rbuf[n].iprol[v].bjs;
@@ -365,11 +713,14 @@ void MeshBoundaryValuesFC::ProlongateFC(DvceFaceFld4D<Real> &b, DvceFaceFld4D<Re
         // Prolongate face-centered fields at shared faces betwen fine and coarse cells
         // by calling inlined prolongation operator for FC variables
         if (v==0) {
-          ProlongFCSharedX1Face(m,k,j,i,fk,fj,fi,multi_d,three_d,cb.x1f,b.x1f);
+          ProlongFCSharedX1FaceOwned(m,nnghbr,k,j,i,fk,fj,fi,ox1,ox2,ox3,my_lev,
+                                     multi_d,three_d,indcs,nghbr,cb.x1f,b.x1f);
         } else if (v==1) {
-          ProlongFCSharedX2Face(m,k,j,i,fk,fj,fi,three_d,cb.x2f,b.x2f);
+          ProlongFCSharedX2FaceOwned(m,nnghbr,k,j,i,fk,fj,fi,ox1,ox2,ox3,my_lev,
+                                     three_d,indcs,nghbr,cb.x2f,b.x2f);
         } else {
-          ProlongFCSharedX3Face(m,k,j,i,fk,fj,fi,multi_d,cb.x3f,b.x3f);
+          ProlongFCSharedX3FaceOwned(m,nnghbr,k,j,i,fk,fj,fi,ox1,ox2,ox3,my_lev,
+                                     multi_d,indcs,nghbr,cb.x3f,b.x3f);
         }
       });
     }
@@ -392,6 +743,10 @@ void MeshBoundaryValuesFC::ProlongateFC(DvceFaceFld4D<Real> &b, DvceFaceFld4D<Re
 
     // only prolongate when neighbor exists and is at coarser level
     if ((nghbr.d_view(m,n).gid >= 0) && (nghbr.d_view(m,n).lev < mblev.d_view(m))) {
+      int ox1, ox2, ox3;
+      NeighborOffsetFromIndex(n, ox1, ox2, ox3);
+      const int my_lev = mblev.d_view(m);
+
       // use prolongation indices of different field components for interior fine cells
       int il = rbuf[n].iprol[2].bis;
       int iu = rbuf[n].iprol[2].bie;
@@ -419,10 +774,14 @@ void MeshBoundaryValuesFC::ProlongateFC(DvceFaceFld4D<Real> &b, DvceFaceFld4D<Re
 
         if (one_d) {
           // In 1D, interior face field is trivial
-          b.x1f(m,fk,fj,fi+1) = 0.5*(b.x1f(m,fk,fj,fi) + b.x1f(m,fk,fj,fi+2));
+          StoreProlongatedFCFace(2, m, nnghbr, 0, fk, fj, fi+1, ox1, ox2, ox3,
+                                 my_lev, indcs, nghbr,
+                                 0.5*(b.x1f(m,fk,fj,fi) + b.x1f(m,fk,fj,fi+2)),
+                                 b.x1f);
         } else {
           // in multi-D call inlined prolongation operator for FC fields at internal faces
-          ProlongFCInternal(m,fk,fj,fi,three_d,b);
+          ProlongFCInternalOwned(m,nnghbr,fk,fj,fi,ox1,ox2,ox3,my_lev,
+                                 three_d,indcs,nghbr,b);
         }
       });
     }

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -22,6 +22,7 @@
 #include "mesh_refinement.hpp"
 #include "refinement_criteria.hpp"
 
+#include "dyn_grmhd/dyn_grmhd.hpp"
 #include "hydro/hydro.hpp"
 #include "mhd/mhd.hpp"
 #include "radiation/radiation.hpp"
@@ -42,6 +43,7 @@
 MeshRefinement::MeshRefinement(Mesh *pm, ParameterInput *pin) :
   pmy_mesh(pm),
   refine_flag("rflag",pm->nmb_total),
+  fc_amr_repair("fc_amr_repair",pm->nmb_total),
   ncyc_since_ref("cyc_since_ref",pm->nmb_total),
   nmb_created(0),
   nmb_deleted(0),
@@ -78,10 +80,13 @@ MeshRefinement::MeshRefinement(Mesh *pm, ParameterInput *pin) :
   // be sure Views are initialized to zero
   for (int m=0; m<(pm->nmb_total); ++m) {
     refine_flag.h_view(m) = 0;
+    fc_amr_repair.h_view(m) = 0;
     ncyc_since_ref(m) = 0;
   }
   refine_flag.template modify<HostMemSpace>();
   refine_flag.template sync<DevExeSpace>();
+  fc_amr_repair.template modify<HostMemSpace>();
+  fc_amr_repair.template sync<DevExeSpace>();
 
   // initialize interpolation weights for prolongation and restriction
   InitInterpWghts();
@@ -123,6 +128,17 @@ void MeshRefinement::AdaptiveMeshRefinement(Driver *pdriver, ParameterInput *pin
     pdriver->InitBoundaryValuesAndPrimitives(pmy_mesh);
 
     MeshBlockPack* pmbp = pmy_mesh->pmb_pack;
+    if (pmbp->pmhd != nullptr) {
+      RepairAMRFC(pmbp->pmhd->b0);
+      if (pmbp->pdyngr == nullptr) {
+        (void) pmbp->pmhd->ConToPrim(pdriver, 0);
+      } else {
+        if (pmbp->pz4c != nullptr) {
+          (void) pmbp->pz4c->ConvertZ4cToADM(pdriver, 0);
+        }
+        (void) pmbp->pdyngr->ConToPrim(pdriver, 0);
+      }
+    }
     if (pmbp->phydro != nullptr) {
       (void) pmbp->phydro->NewTimeStep(pdriver, pdriver->nexp_stages);
     }
@@ -467,6 +483,15 @@ void MeshRefinement::RedistAndRefineMeshBlocks(ParameterInput *pin, int nnew, in
   refine_flag.template modify<HostMemSpace>();
   refine_flag.template sync<DevExeSpace>();
 
+  hydro::Hydro* phydro = pm->pmb_pack->phydro;
+  mhd::MHD* pmhd = pm->pmb_pack->pmhd;
+  radiation::Radiation* prad = pm->pmb_pack->prad;
+  z4c::Z4c* pz4c = pm->pmb_pack->pz4c;
+  adm::ADM* padm = pm->pmb_pack->padm;
+  if ((ndel > 0) && (pmhd != nullptr)) {
+    RestrictFC(pmhd->b0, pmhd->coarse_b0);
+  }
+
   // Step 4.
   // Allocate send/recv buffers for load balancing, post receives.
   // Pack send buffers for load blancing and send data
@@ -480,11 +505,6 @@ void MeshRefinement::RedistAndRefineMeshBlocks(ParameterInput *pin, int nnew, in
   // De-refine (restrict) evolved physics variables for MeshBlocks within this rank.
   // Simply copies data from coarse arrays in source MBs to appropriate octant of fine
   // array in target MB.
-  hydro::Hydro* phydro = pm->pmb_pack->phydro;
-  mhd::MHD* pmhd = pm->pmb_pack->pmhd;
-  radiation::Radiation* prad = pm->pmb_pack->prad;
-  z4c::Z4c* pz4c = pm->pmb_pack->pz4c;
-  adm::ADM* padm = pm->pmb_pack->padm;
   // derefine (if needed)
   if (ndel > 0) {
     if (phydro != nullptr) {
@@ -614,6 +634,13 @@ void MeshRefinement::RedistAndRefineMeshBlocks(ParameterInput *pin, int nnew, in
   pm->pmb_pack->AddCoordinates(pin);
   pm->pmb_pack->pmb->SetNeighbors(pm->ptree, pm->rank_eachmb);
 
+  Kokkos::realloc(fc_amr_repair, new_nmb_total);
+  for (int m=0; m<new_nmb_total; ++m) {
+    fc_amr_repair.h_view(m) = (refine_flag.h_view(newtoold[m]) != 0) ? 1 : 0;
+  }
+  fc_amr_repair.template modify<HostMemSpace>();
+  fc_amr_repair.template sync<DevExeSpace>();
+
   // clean-up
   delete [] newtoold;
   delete [] oldtonew;
@@ -664,6 +691,7 @@ void MeshRefinement::DerefineCCSameRank(DvceArray5D<Real> &a, DvceArray5D<Real> 
   for (int oldm=ombs; oldm<=ombe; ++oldm) {
     if (refine_flag.h_view(oldm) < -1) {  // only derefine if nleaf blocks flagged
       int newm = oldtonew[oldm];
+      if ((oldm > 0) && (oldtonew[oldm-1] == newm)) continue;
       // only copy data if target MB stays on this rank
       if (new_rank_eachmb[newm] == global_variable::my_rank) {
         for (int l=0; l<nleaf; l++) {
@@ -720,6 +748,7 @@ void MeshRefinement::DerefineFCSameRank(DvceFaceFld4D<Real> &b, DvceFaceFld4D<Re
   for (int oldm=ombs; oldm<=ombe; ++oldm) {
     if (refine_flag.h_view(oldm) < -1) {  // only derefine if nleaf blocks flagged
       int newm = oldtonew[oldm];
+      if ((oldm > 0) && (oldtonew[oldm-1] == newm)) continue;
       // only copy data if target MB stays on this rank
       if (new_rank_eachmb[newm] == global_variable::my_rank) {
         for (int l=0; l<nleaf; l++) {
@@ -1119,6 +1148,44 @@ void MeshRefinement::RefineFC(DualArray1D<int> &n2o, DvceFaceFld4D<Real> &b,
         b.x1f(m,fk,fj,fi+1) = 0.5*(b.x1f(m,fk,fj,fi) + b.x1f(m,fk,fj,fi+2));
       } else {
         // in multi-D call inlined prolongation operator for FC fields at internal faces
+        ProlongFCInternal(m,fk,fj,fi,three_d,b);
+      }
+    }
+  });
+
+  return;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void MeshRefinement::RepairAMRFC
+//! \brief Recompute internal face-centered fields in AMR-affected MeshBlocks after
+//! exterior faces have been finalized by boundary exchange/prolongation.
+
+void MeshRefinement::RepairAMRFC(DvceFaceFld4D<Real> &b) {
+  auto &indcs = pmy_mesh->mb_indcs;
+  auto &is = indcs.is;
+  auto &js = indcs.js;
+  auto &ks = indcs.ks;
+  auto &cis = indcs.cis, &cie = indcs.cie;
+  auto &cjs = indcs.cjs, &cje = indcs.cje;
+  auto &cks = indcs.cks, &cke = indcs.cke;
+
+  const int nmb = pmy_mesh->pmb_pack->nmb_thispack;
+  const int mbs = pmy_mesh->gids_eachrank[global_variable::my_rank];
+  bool &one_d = pmy_mesh->one_d;
+  bool &three_d = pmy_mesh->three_d;
+  auto &repair = fc_amr_repair;
+
+  par_for("RepairAMRFC",DevExeSpace(), 0,(nmb-1), cks,cke, cjs,cje, cis,cie,
+  KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+    if (repair.d_view(m + mbs) != 0) {
+      int fi = (i - cis)*2 + is;
+      int fj = (j - cjs)*2 + js;
+      int fk = (k - cks)*2 + ks;
+
+      if (one_d) {
+        b.x1f(m,fk,fj,fi+1) = 0.5*(b.x1f(m,fk,fj,fi) + b.x1f(m,fk,fj,fi+2));
+      } else {
         ProlongFCInternal(m,fk,fj,fi,three_d,b);
       }
     }

--- a/src/mesh/mesh_refinement.hpp
+++ b/src/mesh/mesh_refinement.hpp
@@ -57,6 +57,7 @@ class MeshRefinement {
 
   // following 2x Views are dimensioned [nmb_total]
   DualArray1D<int> refine_flag;    // refinement flag for each MeshBlock
+  DualArray1D<int> fc_amr_repair;  // marks MBs needing post-AMR FC interior repair
   HostArray1D<int> ncyc_since_ref; // # of cycles since MB last refined/derefined
 
   // following 4x arrays allocated with length [nranks] only with AMR
@@ -114,6 +115,7 @@ class MeshRefinement {
   void RefineCC(DualArray1D<int> &n2o, DvceArray5D<Real> &a, DvceArray5D<Real> &ca,
                 bool is_z4c=false);
   void RefineFC(DualArray1D<int> &n2o, DvceFaceFld4D<Real> &b, DvceFaceFld4D<Real> &cb);
+  void RepairAMRFC(DvceFaceFld4D<Real> &b);
 
   void RestrictCC(DvceArray5D<Real> &a, DvceArray5D<Real> &ca, bool is_z4c=false);
   void RestrictFC(DvceFaceFld4D<Real> &b, DvceFaceFld4D<Real> &cb);

--- a/src/pgen/pgen.cpp
+++ b/src/pgen/pgen.cpp
@@ -901,6 +901,8 @@ void ProblemGenerator::CallProblemGenerator(ParameterInput *pin, bool is_restart
     BondiAccretion(pin, is_restart);
   } else if (pgen_fun_name.compare("cshock") == 0) {
     CShock(pin, is_restart);
+  } else if (pgen_fun_name.compare("divb_amr") == 0) {
+    DivBAMR(pin, is_restart);
   } else if (pgen_fun_name.compare("linear_wave") == 0) {
     LinearWave(pin, is_restart);
   } else if (pgen_fun_name.compare("implode") == 0) {

--- a/src/pgen/pgen.hpp
+++ b/src/pgen/pgen.hpp
@@ -60,6 +60,7 @@ class ProblemGenerator {
   void AlfvenWave(ParameterInput *pin, const bool restart);
   void BondiAccretion(ParameterInput *pin, const bool restart);
   void CShock(ParameterInput *pin, const bool restart);
+  void DivBAMR(ParameterInput *pin, const bool restart);
   void Diffusion(ParameterInput *pin, const bool restart);
   void LinearWave(ParameterInput *pin, const bool restart);
   void LWImplode(ParameterInput *pin, const bool restart);

--- a/src/pgen/tests/divb_amr.cpp
+++ b/src/pgen/tests/divb_amr.cpp
@@ -1,0 +1,411 @@
+//========================================================================================
+// AthenaXXX astrophysical plasma code
+// Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the Athena code team
+// Licensed under the 3-clause BSD License (the "LICENSE")
+//========================================================================================
+//! \file divb_amr.cpp
+//! \brief High-sensitivity AMR test for preservation of the face-centered div(B)=0
+//! constraint in 1D/2D/3D.
+
+// C/C++ headers
+#include <algorithm>  // min, max
+#include <cmath>      // fabs(), sin(), cos()
+#include <cstdlib>    // exit()
+#include <iostream>   // endl
+
+// Athena++ headers
+#include "athena.hpp"
+#include "globals.hpp"
+#include "parameter_input.hpp"
+#include "coordinates/cell_locations.hpp"
+#include "mesh/mesh.hpp"
+#include "eos/eos.hpp"
+#include "mhd/mhd.hpp"
+#include "pgen/pgen.hpp"
+
+void DivBAMRHistory(HistoryData *pdata, Mesh *pm);
+void DivBAMRRefinementCondition(MeshBlockPack *pmbp);
+
+namespace {
+
+struct DivBAMRConfig {
+  Real rho0 = 1.0;
+  Real pgas0 = 10.0;
+  Real vx0 = 0.08;
+  Real vy0 = 0.05;
+  Real vz0 = 0.03;
+  Real guide_b1 = 0.7;
+  Real guide_b2 = 0.2;
+  Real guide_b3 = -0.15;
+  Real field_amp = 0.25;
+  Real field_k = 2.0;
+  Real divb_bnorm = 1.0;
+  Real x1min = 0.0;
+  Real x1max = 1.0;
+  Real x2min = 0.0;
+  Real x2max = 1.0;
+  Real x3min = 0.0;
+  Real x3max = 1.0;
+  int target_level = 0;
+};
+
+DivBAMRConfig divb_amr;
+
+KOKKOS_INLINE_FUNCTION
+Real Phase(const Real x, const Real xmin, const Real xmax, const Real k) {
+  const Real width = xmax - xmin;
+  if (width <= 0.0) return 0.0;
+  return 2.0*M_PI*k*(x - xmin)/width;
+}
+
+KOKKOS_INLINE_FUNCTION
+Real A1(const Real x1, const Real x2, const Real x3, const DivBAMRConfig cfg) {
+  const Real x = Phase(x1, cfg.x1min, cfg.x1max, cfg.field_k);
+  const Real y = Phase(x2, cfg.x2min, cfg.x2max, cfg.field_k);
+  const Real z = Phase(x3, cfg.x3min, cfg.x3max, cfg.field_k);
+  const Real scale = cfg.field_amp/(2.0*M_PI*cfg.field_k);
+  return scale*(0.50*std::sin(y + 2.0*z) + 0.33*std::cos(2.0*x - z)
+              + 0.21*std::sin(3.0*y - x + z));
+}
+
+KOKKOS_INLINE_FUNCTION
+Real A2(const Real x1, const Real x2, const Real x3, const DivBAMRConfig cfg) {
+  const Real x = Phase(x1, cfg.x1min, cfg.x1max, cfg.field_k);
+  const Real y = Phase(x2, cfg.x2min, cfg.x2max, cfg.field_k);
+  const Real z = Phase(x3, cfg.x3min, cfg.x3max, cfg.field_k);
+  const Real scale = cfg.field_amp/(2.0*M_PI*cfg.field_k);
+  return scale*(0.47*std::sin(z + 2.0*x) + 0.29*std::cos(2.0*y - x)
+              + 0.19*std::sin(3.0*z - y + x));
+}
+
+KOKKOS_INLINE_FUNCTION
+Real A3(const Real x1, const Real x2, const Real x3, const DivBAMRConfig cfg) {
+  const Real x = Phase(x1, cfg.x1min, cfg.x1max, cfg.field_k);
+  const Real y = Phase(x2, cfg.x2min, cfg.x2max, cfg.field_k);
+  const Real z = Phase(x3, cfg.x3min, cfg.x3max, cfg.field_k);
+  const Real scale = cfg.field_amp/(2.0*M_PI*cfg.field_k);
+  return scale*(0.53*std::sin(x + 2.0*y) + 0.31*std::cos(2.0*z - y)
+              + 0.23*std::sin(3.0*x - z + y));
+}
+
+KOKKOS_INLINE_FUNCTION
+Real WrapUnit(Real x) {
+  while (x < 0.0) x += 1.0;
+  while (x >= 1.0) x -= 1.0;
+  return x;
+}
+
+KOKKOS_INLINE_FUNCTION
+Real PeriodicDistance(const Real a, const Real b) {
+  const Real d = fabs(a - b);
+  return fmin(d, 1.0 - d);
+}
+
+KOKKOS_INLINE_FUNCTION
+Real CenterUnit(const Real xmin, const Real xmax, const Real mesh_min,
+                const Real mesh_max) {
+  const Real width = mesh_max - mesh_min;
+  if (width <= 0.0) return 0.0;
+  return WrapUnit((0.5*(xmin + xmax) - mesh_min)/width);
+}
+
+KOKKOS_INLINE_FUNCTION
+Real HalfWidthUnit(const Real xmin, const Real xmax, const Real mesh_min,
+                   const Real mesh_max) {
+  const Real width = mesh_max - mesh_min;
+  if (width <= 0.0) return 0.5;
+  return 0.5*(xmax - xmin)/width;
+}
+
+KOKKOS_INLINE_FUNCTION
+bool OverlapsPeriodicBox(const RegionSize &sz, const RegionSize &mesh_size,
+                         const Real c1, const Real c2, const Real c3,
+                         const Real h1, const Real h2, const Real h3,
+                         const bool multi_d, const bool three_d) {
+  const Real x1c = CenterUnit(sz.x1min, sz.x1max, mesh_size.x1min, mesh_size.x1max);
+  const Real x1h = HalfWidthUnit(sz.x1min, sz.x1max, mesh_size.x1min, mesh_size.x1max);
+  bool overlaps = PeriodicDistance(x1c, c1) <= (x1h + h1);
+
+  if (multi_d) {
+    const Real x2c = CenterUnit(sz.x2min, sz.x2max, mesh_size.x2min, mesh_size.x2max);
+    const Real x2h = HalfWidthUnit(sz.x2min, sz.x2max, mesh_size.x2min, mesh_size.x2max);
+    overlaps = overlaps && (PeriodicDistance(x2c, c2) <= (x2h + h2));
+  }
+  if (three_d) {
+    const Real x3c = CenterUnit(sz.x3min, sz.x3max, mesh_size.x3min, mesh_size.x3max);
+    const Real x3h = HalfWidthUnit(sz.x3min, sz.x3max, mesh_size.x3min, mesh_size.x3max);
+    overlaps = overlaps && (PeriodicDistance(x3c, c3) <= (x3h + h3));
+  }
+  return overlaps;
+}
+
+KOKKOS_INLINE_FUNCTION
+bool InRefinementPattern(const RegionSize &sz, const RegionSize &mesh_size,
+                         const Real phase, const bool multi_d, const bool three_d) {
+  const bool box1 = OverlapsPeriodicBox(
+      sz, mesh_size, WrapUnit(0.19 + 0.113*phase), WrapUnit(0.31 + 0.071*phase),
+      WrapUnit(0.47 + 0.053*phase), 0.135, 0.110, 0.090, multi_d, three_d);
+  const bool box2 = OverlapsPeriodicBox(
+      sz, mesh_size, WrapUnit(0.63 - 0.097*phase), WrapUnit(0.72 + 0.127*phase),
+      WrapUnit(0.24 - 0.061*phase), 0.115, 0.155, 0.105, multi_d, three_d);
+  const bool box3 = OverlapsPeriodicBox(
+      sz, mesh_size, WrapUnit(0.82 + 0.049*phase), WrapUnit(0.18 - 0.109*phase),
+      WrapUnit(0.76 + 0.083*phase), 0.075, 0.095, 0.145, multi_d, three_d);
+  return box1 || box2 || box3;
+}
+
+} // end anonymous namespace
+
+//----------------------------------------------------------------------------------------
+//! \fn void ProblemGenerator::DivBAMR()
+//! \brief Initialize a high-gradient, discretely divergence-free magnetic field and
+//! moving AMR pattern for div(B) preservation tests.
+
+void ProblemGenerator::DivBAMR(ParameterInput *pin, const bool restart) {
+  user_ref_func = DivBAMRRefinementCondition;
+  user_hist_func = DivBAMRHistory;
+
+  MeshBlockPack *pmbp = pmy_mesh_->pmb_pack;
+  if (pmbp->pmhd == nullptr) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+              << "divb_amr can only be run in MHD, but no <mhd> block is present"
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  divb_amr.rho0 = pin->GetOrAddReal("problem", "rho0", 1.0);
+  divb_amr.pgas0 = pin->GetOrAddReal("problem", "pgas0", 10.0);
+  divb_amr.vx0 = pin->GetOrAddReal("problem", "vx0", 0.08);
+  divb_amr.vy0 = pin->GetOrAddReal("problem", "vy0", 0.05);
+  divb_amr.vz0 = pin->GetOrAddReal("problem", "vz0", 0.03);
+  divb_amr.guide_b1 = pin->GetOrAddReal("problem", "guide_b1", 0.7);
+  divb_amr.guide_b2 = pin->GetOrAddReal("problem", "guide_b2", 0.2);
+  divb_amr.guide_b3 = pin->GetOrAddReal("problem", "guide_b3", -0.15);
+  divb_amr.field_amp = pin->GetOrAddReal("problem", "field_amp", 0.25);
+  divb_amr.field_k = pin->GetOrAddReal("problem", "field_k", 2.0);
+  divb_amr.x1min = pmy_mesh_->mesh_size.x1min;
+  divb_amr.x1max = pmy_mesh_->mesh_size.x1max;
+  divb_amr.x2min = pmy_mesh_->mesh_size.x2min;
+  divb_amr.x2max = pmy_mesh_->mesh_size.x2max;
+  divb_amr.x3min = pmy_mesh_->mesh_size.x3min;
+  divb_amr.x3max = pmy_mesh_->mesh_size.x3max;
+  const int refine_levels = pin->GetOrAddInteger("problem", "refine_levels", 2);
+  divb_amr.target_level = std::min(pmy_mesh_->root_level + refine_levels,
+                                   pmy_mesh_->max_level);
+  const Real default_bnorm = std::max(static_cast<Real>(1.0),
+      std::abs(divb_amr.guide_b1) + std::abs(divb_amr.guide_b2)
+    + std::abs(divb_amr.guide_b3) + 6.0*std::abs(divb_amr.field_amp));
+  divb_amr.divb_bnorm = pin->GetOrAddReal("problem", "divb_bnorm", default_bnorm);
+
+  if (restart) return;
+
+  auto &indcs = pmy_mesh_->mb_indcs;
+  int &is = indcs.is; int &ie = indcs.ie;
+  int &js = indcs.js; int &je = indcs.je;
+  int &ks = indcs.ks; int &ke = indcs.ke;
+  int &nx1 = indcs.nx1;
+  int &nx2 = indcs.nx2;
+  int &nx3 = indcs.nx3;
+  const bool multi_d = pmy_mesh_->multi_d;
+  const bool three_d = pmy_mesh_->three_d;
+
+  int nmb = pmbp->nmb_thispack;
+  EOS_Data &eos = pmbp->pmhd->peos->eos_data;
+  const Real gm1 = eos.gamma - 1.0;
+  auto &u0 = pmbp->pmhd->u0;
+  auto &b0 = pmbp->pmhd->b0;
+  auto &size = pmbp->pmb->mb_size;
+  const auto cfg = divb_amr;
+
+  int ncells1 = nx1 + 2*indcs.ng;
+  int ncells2 = (nx2 > 1) ? (nx2 + 2*indcs.ng) : 2;
+  int ncells3 = (nx3 > 1) ? (nx3 + 2*indcs.ng) : 2;
+  DvceArray4D<Real> a1("divb-amr-a1", nmb, ncells3, ncells2, ncells1);
+  DvceArray4D<Real> a2("divb-amr-a2", nmb, ncells3, ncells2, ncells1);
+  DvceArray4D<Real> a3("divb-amr-a3", nmb, ncells3, ncells2, ncells1);
+
+  par_for("divb_amr_vector_potential", DevExeSpace(), 0, nmb-1, ks, ke+1, js, je+1,
+  is, ie+1, KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    const Real x1min = size.d_view(m).x1min;
+    const Real x1max = size.d_view(m).x1max;
+    const Real x2min = size.d_view(m).x2min;
+    const Real x2max = size.d_view(m).x2max;
+    const Real x3min = size.d_view(m).x3min;
+    const Real x3max = size.d_view(m).x3max;
+
+    const Real x1v = CellCenterX(i - is, nx1, x1min, x1max);
+    const Real x1f = LeftEdgeX(i - is, nx1, x1min, x1max);
+    const Real x2v = CellCenterX(j - js, nx2, x2min, x2max);
+    const Real x2f = LeftEdgeX(j - js, nx2, x2min, x2max);
+    const Real x3v = CellCenterX(k - ks, nx3, x3min, x3max);
+    const Real x3f = LeftEdgeX(k - ks, nx3, x3min, x3max);
+
+    a1(m,k,j,i) = A1(x1v, x2f, x3f, cfg);
+    a2(m,k,j,i) = A2(x1f, x2v, x3f, cfg);
+    a3(m,k,j,i) = A3(x1f, x2f, x3v, cfg);
+  });
+
+  par_for("divb_amr_b1", DevExeSpace(), 0, nmb-1, ks, ke, js, je, is, ie+1,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real b1 = cfg.guide_b1;
+    if (multi_d) {
+      b1 += (a3(m,k,j+1,i) - a3(m,k,j,i))/size.d_view(m).dx2;
+    }
+    if (three_d) {
+      b1 -= (a2(m,k+1,j,i) - a2(m,k,j,i))/size.d_view(m).dx3;
+    }
+    b0.x1f(m,k,j,i) = b1;
+  });
+
+  par_for("divb_amr_b2", DevExeSpace(), 0, nmb-1, ks, ke, js, je+1, is, ie,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real b2 = cfg.guide_b2 - (a3(m,k,j,i+1) - a3(m,k,j,i))/size.d_view(m).dx1;
+    if (three_d) {
+      b2 += (a1(m,k+1,j,i) - a1(m,k,j,i))/size.d_view(m).dx3;
+    }
+    b0.x2f(m,k,j,i) = b2;
+  });
+
+  par_for("divb_amr_b3", DevExeSpace(), 0, nmb-1, ks, ke+1, js, je, is, ie,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real b3 = cfg.guide_b3 + (a2(m,k,j,i+1) - a2(m,k,j,i))/size.d_view(m).dx1;
+    if (multi_d) {
+      b3 -= (a1(m,k,j+1,i) - a1(m,k,j,i))/size.d_view(m).dx2;
+    }
+    b0.x3f(m,k,j,i) = b3;
+  });
+
+  par_for("divb_amr_cons", DevExeSpace(), 0, nmb-1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    const Real rho = cfg.rho0;
+    u0(m,IDN,k,j,i) = rho;
+    u0(m,IM1,k,j,i) = rho*cfg.vx0;
+    u0(m,IM2,k,j,i) = rho*(multi_d ? cfg.vy0 : 0.0);
+    u0(m,IM3,k,j,i) = rho*(three_d ? cfg.vz0 : 0.0);
+    const Real bx = 0.5*(b0.x1f(m,k,j,i) + b0.x1f(m,k,j,i+1));
+    const Real by = 0.5*(b0.x2f(m,k,j,i) + b0.x2f(m,k,j+1,i));
+    const Real bz = 0.5*(b0.x3f(m,k,j,i) + b0.x3f(m,k+1,j,i));
+    const Real v2 = SQR(cfg.vx0) + (multi_d ? SQR(cfg.vy0) : 0.0)
+                  + (three_d ? SQR(cfg.vz0) : 0.0);
+    u0(m,IEN,k,j,i) = cfg.pgas0/gm1 + 0.5*rho*v2
+                    + 0.5*(SQR(bx) + SQR(by) + SQR(bz));
+  });
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void DivBAMRRefinementCondition()
+//! \brief Moving periodic box pattern that creates many coarse/fine edges and corners.
+
+void DivBAMRRefinementCondition(MeshBlockPack *pmbp) {
+  Mesh *pmesh = pmbp->pmesh;
+  auto &refine_flag = pmesh->pmr->refine_flag;
+  auto &mblev = pmbp->pmb->mb_lev;
+  auto &mb_size = pmbp->pmb->mb_size;
+  const int nmb = pmbp->nmb_thispack;
+  const int mbs = pmesh->gids_eachrank[global_variable::my_rank];
+  const int root_level = pmesh->root_level;
+  const bool multi_d = pmesh->multi_d;
+  const bool three_d = pmesh->three_d;
+  const RegionSize mesh_size = pmesh->mesh_size;
+  const auto cfg = divb_amr;
+  const Real phase = pmesh->time + static_cast<Real>(pmesh->ncycle);
+
+  par_for("divb_amr_refinement", DevExeSpace(), 0, nmb-1, KOKKOS_LAMBDA(int m) {
+    const bool refine_region = InRefinementPattern(
+        mb_size.d_view(m), mesh_size, phase, multi_d, three_d);
+    const int level = mblev.d_view(m);
+    if (refine_region && (level < cfg.target_level)) {
+      refine_flag.d_view(m + mbs) = 1;
+    } else if ((!refine_region) && (level > root_level)) {
+      refine_flag.d_view(m + mbs) = -1;
+    }
+  });
+
+  refine_flag.template modify<DevExeSpace>();
+  refine_flag.template sync<HostMemSpace>();
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void DivBAMRHistory()
+//! \brief Direct discrete divergence diagnostics over active cells.
+
+void DivBAMRHistory(HistoryData *pdata, Mesh *pm) {
+  pdata->nhist = 8;
+  pdata->label[0] = "max_divb";
+  pdata->label[1] = "max_ndiv";
+  pdata->label[2] = "sum_divb";
+  pdata->label[3] = "sum_d2";
+  pdata->label[4] = "sum_ndiv";
+  pdata->label[5] = "sum_n2";
+  pdata->label[6] = "vol";
+  pdata->label[7] = "ncell";
+
+  auto &b = pm->pmb_pack->pmhd->b0;
+  auto &size = pm->pmb_pack->pmb->mb_size;
+  auto &indcs = pm->mb_indcs;
+  const int is = indcs.is;
+  const int js = indcs.js;
+  const int ks = indcs.ks;
+  const int nx1 = indcs.nx1;
+  const int nx2 = indcs.nx2;
+  const int nx3 = indcs.nx3;
+  const int nmkji = (pm->pmb_pack->nmb_thispack)*nx3*nx2*nx1;
+  const int nkji = nx3*nx2*nx1;
+  const int nji = nx2*nx1;
+  const bool multi_d = pm->multi_d;
+  const bool three_d = pm->three_d;
+  const auto cfg = divb_amr;
+
+  array_sum::GlobalSum sum_this_mb;
+  Real max_abs_divb = 0.0;
+  Real max_norm_divb = 0.0;
+  Kokkos::parallel_reduce(
+      "divb_amr_history", Kokkos::RangePolicy<>(DevExeSpace(), 0, nmkji),
+  KOKKOS_LAMBDA(const int &idx, array_sum::GlobalSum &mb_sum, Real &max_abs,
+                Real &max_norm) {
+    const int m = idx/nkji;
+    int k = (idx - m*nkji)/nji;
+    int j = (idx - m*nkji - k*nji)/nx1;
+    const int i = (idx - m*nkji - k*nji - j*nx1) + is;
+    j += js;
+    k += ks;
+
+    Real divb = (b.x1f(m,k,j,i+1) - b.x1f(m,k,j,i))/size.d_view(m).dx1;
+    Real dx_min = size.d_view(m).dx1;
+    Real vol = size.d_view(m).dx1;
+    if (multi_d) {
+      divb += (b.x2f(m,k,j+1,i) - b.x2f(m,k,j,i))/size.d_view(m).dx2;
+      dx_min = fmin(dx_min, size.d_view(m).dx2);
+      vol *= size.d_view(m).dx2;
+    }
+    if (three_d) {
+      divb += (b.x3f(m,k+1,j,i) - b.x3f(m,k,j,i))/size.d_view(m).dx3;
+      dx_min = fmin(dx_min, size.d_view(m).dx3);
+      vol *= size.d_view(m).dx3;
+    }
+
+    const Real abs_divb = fabs(divb);
+    const Real norm_divb = abs_divb*dx_min/cfg.divb_bnorm;
+
+    array_sum::GlobalSum hvars;
+    hvars.the_array[2] = abs_divb*vol;
+    hvars.the_array[3] = SQR(divb)*vol;
+    hvars.the_array[4] = norm_divb*vol;
+    hvars.the_array[5] = SQR(norm_divb)*vol;
+    hvars.the_array[6] = vol;
+    hvars.the_array[7] = 1.0;
+    for (int n=8; n<NREDUCTION_VARIABLES; ++n) {
+      hvars.the_array[n] = 0.0;
+    }
+    max_abs = fmax(max_abs, abs_divb);
+    max_norm = fmax(max_norm, norm_divb);
+    mb_sum += hvars;
+  }, Kokkos::Sum<array_sum::GlobalSum>(sum_this_mb),
+     Kokkos::Max<Real>(max_abs_divb), Kokkos::Max<Real>(max_norm_divb));
+
+  pdata->hdata[0] = max_abs_divb;
+  pdata->hdata[1] = max_norm_divb;
+  for (int n=2; n<pdata->nhist; ++n) {
+    pdata->hdata[n] = sum_this_mb.the_array[n];
+  }
+}

--- a/tst/scripts/mhd/mhd_divb_amr.py
+++ b/tst/scripts/mhd/mhd_divb_amr.py
@@ -1,0 +1,86 @@
+# Regression test for face-centered div(B) preservation under moving AMR.
+#
+# The divb_amr pgen initializes B from a discrete vector potential, then forces a moving
+# AMR refinement pattern. This script checks direct face-centered divergence histories in
+# 1D, 2D, and 3D with one through five physical AMR refinement levels.
+
+import logging
+import math
+import os
+import sys
+
+import scripts.utils.athena as athena
+
+sys.path.insert(0, '../vis/python')
+import athena_read  # noqa
+
+athena_read.check_nan_flag = True
+logger = logging.getLogger('athena' + __name__[7:])
+
+_CASES = [
+    ('1D', 'tests/divb_amr_1d.athinput', 'DivBAMR1D', 64, 24, []),
+    ('2D', 'tests/divb_amr_2d.athinput', 'DivBAMR2D', 48*48, 20, []),
+]
+_CASES += [
+    ('3D-L{0}'.format(level), 'tests/divb_amr_3d.athinput',
+     'DivBAMR3DL{0}'.format(level), 32*32*32, 8,
+     ['mesh_refinement/num_levels={0}'.format(level + 1),
+      'problem/refine_levels={0}'.format(level),
+      'mesh_refinement/max_nmb_per_rank=16384',
+      'time/nlim=8'])
+    for level in range(1, 6)
+]
+
+_MAX_NDIV_TOL = 2.0e-11
+_L1_NDIV_TOL = 2.0e-12
+_L2_NDIV_TOL = 5.0e-12
+
+
+def run(**kwargs):
+    logger.debug('Running test ' + __name__)
+    for _, input_file, basename, _, _, arguments in _CASES:
+        hst_file = os.path.join('build', 'src', basename + '.user.hst')
+        if os.path.exists(hst_file):
+            os.remove(hst_file)
+        athena.run(input_file, [
+            'job/basename=' + basename,
+            'output1/dcycle=1',
+        ] + arguments)
+
+
+def analyze():
+    logger.debug('Analyzing test ' + __name__)
+    analyze_status = True
+
+    for label, _, basename, root_ncell, min_rows, _ in _CASES:
+        hst_file = os.path.join('build', 'src', basename + '.user.hst')
+        data = athena_read.hst(hst_file)
+
+        max_ndiv = max(data['max_ndiv'])
+        l1_ndiv = max(s/v for s, v in zip(data['sum_ndiv'], data['vol']))
+        l2_ndiv = max(math.sqrt(s/v) for s, v in zip(data['sum_n2'], data['vol']))
+        max_ncell = max(data['ncell'])
+
+        if len(data['time']) < min_rows:
+            logger.warning('{0} AMR div(B) history is too short: {1} rows, expected {2}'.
+                           format(label, len(data['time']), min_rows))
+            analyze_status = False
+        if max_ncell <= root_ncell:
+            logger.warning('{0} AMR div(B) test did not refine: max_ncell={1:g}, '
+                           'root_ncell={2:g}'.
+                           format(label, max_ncell, root_ncell))
+            analyze_status = False
+        if max_ndiv > _MAX_NDIV_TOL:
+            logger.warning('{0} max normalized div(B) too large: {1:g} threshold {2:g}'.
+                           format(label, max_ndiv, _MAX_NDIV_TOL))
+            analyze_status = False
+        if l1_ndiv > _L1_NDIV_TOL:
+            logger.warning('{0} L1 normalized div(B) too large: {1:g} threshold {2:g}'.
+                           format(label, l1_ndiv, _L1_NDIV_TOL))
+            analyze_status = False
+        if l2_ndiv > _L2_NDIV_TOL:
+            logger.warning('{0} L2 normalized div(B) too large: {1:g} threshold {2:g}'.
+                           format(label, l2_ndiv, _L2_NDIV_TOL))
+            analyze_status = False
+
+    return analyze_status


### PR DESCRIPTION
## Summary

Fixes deep-AMR face-centered magnetic-field preservation by tightening ownership checks for face-centered boundary/prolongation paths, refreshing restricted MHD face fields before AMR packing, repairing AMR-affected internal faces after exterior boundary exchange, and refreshing MHD primitives from the repaired field.

Adds a lean `divb_amr` regression problem with 1D, 2D, and 3D moving AMR sweep inputs plus a test driver.

## Why

PR 732 handled one boundary overwrite path, but deeper 2D/3D AMR rebuild/restriction/prolongation flows could still disturb CT face fields after internal Toth-Roe faces had been computed.

## Validation

Not rerun during this PR creation step. The branch adds `tst/scripts/mhd/mhd_divb_amr.py` and `inputs/tests/divb_amr_{1d,2d,3d}.athinput` to cover the regression.