### PR TITLE
[bug fix] use same-cell fluid state for derived temperature output

### DIFF
--- a/src/outputs/derived_variables.cpp
+++ b/src/outputs/derived_variables.cpp
@@ -92,16 +92,22 @@ void BaseTypeOutput::ComputeDerivedVariable(std::string name, Mesh *pm) {
   int &i_dv = out_params.i_derived;
   int &n_dv = out_params.n_derived;
 
-  // temperature = pressure / density
+  // specific internal energy proxy = eint / density
   if (name.compare("temperature") == 0) {
     if (derived_var.extent(4) <= 1)
       Kokkos::realloc(derived_var, nmb, n_dv, n3, n2, n1);
     auto dv = derived_var;
-    auto &w0_ = (name.compare("hydro_wz") == 0)?
+    if (pm->pmb_pack->phydro == nullptr && pm->pmb_pack->pmhd == nullptr) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "Temperature output requested but no hydro or MHD "
+                << "module constructed." << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    auto &w0_ = (pm->pmb_pack->phydro != nullptr) ?
       pm->pmb_pack->phydro->w0 : pm->pmb_pack->pmhd->w0;
     par_for("temperature", DevExeSpace(), 0, (nmb-1), ks, ke, js, je, is, ie,
     KOKKOS_LAMBDA(int m, int k, int j, int i) {
-      dv(m,i_dv,k,j,i) = (w0_(m,IEN,k,j,i+1) / w0_(m,IDN,k,j,i-1));
+      dv(m,i_dv,k,j,i) = w0_(m,IEN,k,j,i) / w0_(m,IDN,k,j,i);
     });
     i_dv += 1; // increment derived variable index
   }


### PR DESCRIPTION
## Summary

Fix the latent derived `temperature` output calculation in `src/outputs/derived_variables.cpp`.

## Root cause

The existing implementation combined `IEN` from cell `i+1` with `IDN` from cell `i-1`, even though the derived value is pointwise. It also tested `name == "hydro_wz"` inside the `temperature` branch, which is always false and therefore selected the MHD primitive array even for Hydro-only calculations.

## Changes

- compute the proxy from `IEN` and `IDN` in the same cell
- select Hydro primitives when a Hydro module exists, otherwise select MHD primitives
- fail explicitly if neither fluid module exists
- clarify that the stored value is a specific-internal-energy proxy rather than a Kelvin conversion

## Scope

This PR intentionally repairs only the latent source defect. It does not register `temperature` as a supported output variable or define CGL-specific temperature semantics.

## Validation

- `git diff --check`
- source scan confirms the neighboring-cell expression is absent under `src/`
- `cd tst && /Users/dbf75/.uv/envs/interactive/.venv/bin/python run_test_suite.py --style`
- clean local Release configure and build with `cmake`
- built executable smoke check: `athena -c`